### PR TITLE
OR Any%  - Fix Ice Beam Ranges

### DIFF
--- a/omega-ruby-any-percent-wr-notes/route.mdr
+++ b/omega-ruby-any-percent-wr-notes/route.mdr
@@ -1139,7 +1139,7 @@ Catch Groudon with the Master Ball.
     - Smack Down
     - Earthquake (x2) (Smack Down)
 
-    ::damage[Dragon Pulse]{source="Groudon" special=true movePower=85 stab=true level=46 opponentLevel=46 evs=0 opponentStat=69 offensive=false effectiveness=1 theme=error}
+    ::damage[Dragon Pulse]{source="Groudon" special=true movePower=85 stab=true level=46 opponentLevel=46 evs=0 opponentStat=97 offensive=false effectiveness=2 theme=error}
   :::::
   :::::pokemon[Roselia]
     - Earthquake

--- a/omega-ruby-any-percent-wr-notes/route.mdr
+++ b/omega-ruby-any-percent-wr-notes/route.mdr
@@ -1069,7 +1069,7 @@ Catch Groudon with the Master Ball.
   :::::pokemon[Milotic]
      - Swords Dance
      - Earthquake
-     ::damage[Ice Beam does]{source="Groudon" offensive=false movePower=90 level=45 special=true opponentLevel=46 opponentStat=97 stab=false}  
+     ::damage[Ice Beam does]{source="Groudon" offensive=false movePower=90 level=45 special=true effectiveness=2 opponentLevel=46 opponentStat=97 stab=false}  
   :::::
   :::::pokemon[Whiscash]{info="Faster at 80+ Speed (7+/#/#)" infoColor=blue}
      - Earthquake
@@ -1139,7 +1139,7 @@ Catch Groudon with the Master Ball.
     - Smack Down
     - Earthquake (x2) (Smack Down)
 
-    ::damage[Dragon Pulse]{source="Groudon" special=true movePower=85 stab=true level=46 opponentLevel=46 evs=0 opponentStat=97 offensive=false effectiveness=2 theme=error}
+    ::damage[Dragon Pulse]{source="Groudon" special=true movePower=85 stab=true level=46 opponentLevel=46 evs=0 opponentStat=69 offensive=false effectiveness=1 theme=error}
   :::::
   :::::pokemon[Roselia]
     - Earthquake

--- a/omega-ruby-any-percent-wr-notes/route.mdr
+++ b/omega-ruby-any-percent-wr-notes/route.mdr
@@ -848,7 +848,7 @@ Gym puzzle:
     ::damage[+3 Luster Purge vs Pelliper]{source="Latios" special=true movePower=70 stab=true level=32 evs=1 opponentStat=56 healthThreshold=82 combatStages=3 theme=error}
   :::
 :::::
-Grab Persim Berries (left) Can skip w/ 2 left (Need one for Wallace and Sidney)
+Grab Persim Berries (left) Can skip w/ 2 left (Need one for and Sidney)
 Get the free heal before surfing to Mt. Pyre.
 
 :::::trainer[Team Magma Grunt]
@@ -1067,10 +1067,11 @@ Catch Groudon with the Master Ball.
      - Earthquake
   :::::
   :::::pokemon[Milotic]
+     - Swords Dance
      - Earthquake
+     ::damage[Ice Beam does]{source="Groudon" offensive=false movePower=90 level=45 special=true opponentLevel=46 opponentStat=97 stab=false}  
   :::::
   :::::pokemon[Whiscash]{info="Faster at 80+ Speed (7+/#/#)" infoColor=blue}
-     - Swords Dance
      - Earthquake
   :::::
   :::::pokemon[Sealeo]
@@ -1082,7 +1083,7 @@ Catch Groudon with the Master Ball.
 :::::::
 - Fly to Route 126.
   - Menu:
-    - Equip a Persim Berry on Groudon if it was used on Luvdisc
+    - Equip a Persim Berry if have one extra :info[(NEED ONE FOR SIDNEY)]{color=yellow}
     - Teach Waterfall over Dragon Breath to Latios (Slot 2)
 
 


### PR DESCRIPTION
**Please include the route in the name of the PR (for example, `AS Any% - Fix Archie 2`)**

## Route ID omega-ruby-any-percent-wr-notes

## Summary of changes
Fixed Ice beam damage table, forgot effectiveness originally 
## Checklist
* [*] I have tested these changes and Ranger does not display any errors or warnings.
* [*] All image embeds have relative paths.
* [*] The route contains all fights required for the category.
