### PR TITLE
Omega Ruby Sylveon TAM ~ fixing master ball location in Magma Hideout

### DIFF
--- a/omega-ruby-sylveon-tam/route.mdr
+++ b/omega-ruby-sylveon-tam/route.mdr
@@ -701,16 +701,16 @@ Get the Skitty heal :info[in a flash!]{color=gray}
 
 
 Before the next grunt fight, go down to the puzzle:
-  - Left
+  - Right
   - Middle
-  - Left
-  - Far Left
+  - Right
+  - Right
 
-Go behind the bed and talk to the tree to get the Master Ball.
+Go behind the desk, get Nugget first, then get the Master Ball (talk diagonally).
 
 Exiting the puzzle:
   - Middle
-  - Right
+  - Left
   - Top
 
 :::::trainer[Team Magma Grunt]


### PR DESCRIPTION
## Route ID

omega-ruby-sylveon-tam

## Summary of changes

Changed the puzzle directions and the like in order to pick up the Master Ball in Magma Hideout

## Checklist
* [/] I have tested these changes and Ranger does not display any errors or warnings.
* [/] All image embeds have relative paths.
* [/] The route contains all fights required for the category.
