### PR TITLE
X Wartab Route - Added 8 Protein route, added a ton of useful information, and fixed formatting

### DIFF
--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -136,7 +136,7 @@ Get **5 Luxury Balls**
  ::::
 
   ::::pokemon[Squirtle]
-    - _If used Fury Cutter _
+    - _If used Fury Cutter_
       - Fury Cutter x2
       - _Switch back to Aerial Ace if Withdraw or miss_
     - _Otherwise_
@@ -283,7 +283,7 @@ Pickup **TM65 Shadow Claw** at the branch after the path goes down
  ::::
 :::::
 
-:info[Don't heal poison]{color="red}
+:info[Don't heal poison]{color="red"}
 
 :info[Heal if necessary]{color="yellow"}
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -140,7 +140,7 @@ Get **5 Luxury Balls**
       - Fury Cutter x2
       - _Switch back to Aerial Ace if Withdraw or miss_
     - _Otherwise_
-      Aerial Ace x2 / x3
+      - Aerial Ace x2 / x3
 
     :::if{source="Quacklin" condition="atk=(x/1-16/x)"}
       :::card{theme=error}
@@ -521,7 +521,7 @@ Use a Repel
     :::if{source="Hawlucha" condition="startingLevel=20"}
      - Rock Smash x2 (+ Wing Attack)
      - _If first Rock Smash hits into yellow and gets defense drop, Wing Attack kills_
-     - Teach Fling over Rock Smash
+     - _Teach Fling over Rock Smash_
     :::
   :::::
 :::::::
@@ -543,7 +543,7 @@ Use a Repel
   :::::
   :::::pokemon[Granbull]{info="Remeber HP After" infoColor=pink}
      - Wing Attack x2
-     - Teach Fling over Karate Chop
+     - _Teach Fling over Karate Chop_
     :::if{source="Hawlucha" condition="startingLevel=19"}
      ::damage[Granbull’s Headbutt does at 23]{source="Hawlucha" special=false offensive=false movePower=70 level=23 opponentLevel=24 stab=false opponentStat=66}
     :::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -212,16 +212,16 @@ Pickup the **Star Piece** south of Camphrier Town
 > #### Sell
 > -  Star Piece
 > #### Buy 
-> - 8 Repels (^^)
-> - 4 Super Potions (<)
+> - 8 Repels (^^) (v<)
+> - 4 Super Potions (<) (>v)
 > - 1 Antidote (v)
-> - 2 Awakenings (vv)
+> - 2 Awakenings (vv) (^)
 > #### Buy (If Potion used)
-> - 8 Repels (^^)
-> - 2 Potions (<^)
-> - 3 Super Potions (v)
+> - 8 Repels (^^) (v<)
+> - 2 Potions (<^) (^)
+> - 3 Super Potions (v) (>v)
 > - 1 Antidote (v)
-> - 2 Awakenings (vv)
+> - 2 Awakenings (vv) (^)
 
 Get **Berry Juice**
 
@@ -287,12 +287,6 @@ Pickup **TM65 Shadow Claw** at the branch after the path goes down
       - Swords Dance x2
       - Aerial Ace (x2)
       :info[+4 Aerial Ace 6/16 range]{color=red}
-    :::
-    :::if{source="Quacklin" condition="atk=31" level=17}
-      - _If Level 17_
-      - Leer
-      - Swords Dance x2
-      - Aerial Ace
     :::
     :::if{source="Quacklin" condition="atk=~(x/27+/x)"}
       - Swords Dance x3
@@ -388,7 +382,7 @@ Get massage (conservative estimate 90s for menu → massage, 30s for simple swap
 
 Swap Farfetch’d back to front
 :::if{source="Hawlucha" condition="atk=(x/26+/7+) && startingLevel=19"}
-  :info[_Optional: Don't swap Farfetch'd back to front, Karate Chop is 13/16 to kill Amaura (guaranteed at x/x/26+)_]{color=red}
+  :info[_Optional: Don't swap Farfetch'd back to front, Karate Chop is 13/16 to kill Amaura with (x/26+/7-26) (guaranteed at x/x/26+)_]{color=red}
 :::
 
 
@@ -447,7 +441,7 @@ Swap Farfetch’d back to front
         - Swords Dance
         - Rock Smash
     :::
-    :::if{source="Hawlucha" condition="atk=~(x/x/21+) && startingLevel=20"}
+    :::if{source="Hawlucha" condition="atk=(#/15-/x) && startingLevel=20"}
       - Swords Dance
       - Rock Smash x2
     :::
@@ -519,7 +513,8 @@ Use a Repel
      ::damage[Swords Dance + Karate Chop]{source="Hawlucha" special=false offensive=true healthThreshold=76 movePower=50 combatStages=2 effectiveness=2 level=22 opponentLevel=26 stab=true opponentStat=36 theme=error}
     :::
     :::if{source="Hawlucha" condition="startingLevel=20"}
-     -  Rock Smash x2-3
+     - Rock Smash x2-3
+     - _If first Rock Smash hits into yellow and gets defense drop, Wing Attack kills_
      - Teach Fling over Rock Smash
     :::
   :::::
@@ -531,11 +526,12 @@ Use a Repel
      - Wing Attack
   :::::
   :::::pokemon[Helioptile]{info="Has Quick Attack"}
-     - Karate Chop / Fling
      :::if{source="Hawlucha" condition="startingLevel=19"}
+      - Karate Chop
       ::damage[Heliptile QA does at 23]{source="Hawlucha" special=false offensive=false movePower=40 level=23 opponentLevel=25 stab=true opponentStat=25}
      :::
      :::if{source="Hawlucha" condition="startingLevel=20"}
+      - Fling
       ::damage[Heliptile QA does at 23]{source="Hawlucha" special=false offensive=false movePower=40 level=24 opponentLevel=25 stab=true opponentStat=25}
      :::
   :::::
@@ -714,7 +710,7 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
   :::::
 :::::::
 
-Heal with Soda Pop unless very high HP
+Heal with Soda Pop unless very high HP (you can heal turn 1 if don't need to X Attack)
 
 You are faster than Korrina's Hawlucha with (x/x/22+)
 
@@ -724,10 +720,12 @@ You are faster than Korrina's Hawlucha with (x/x/22+)
 :::::::trainer[Leader Korrina]{info="Important: Remember if you X-Attack here or not" infoColor=yellow}
   :::::pokemon[Mienfoo]
     :::if{source="Hawlucha" condition="atk=(x/x/20+) && startingLevel=19"}
+     - _(Heal if didn't before fight)_
      - Swords Dance (Again if Fake Out)
      - Wing Attack
     :::
     :::if{source="Hawlucha" condition="atk=(x/x/21+) && startingLevel=20"}
+     - _(Heal if didn't before fight)_
      - Swords Dance (Again if Fake Out)
      - Wing Attack
     :::
@@ -952,7 +950,7 @@ Go right after the first climbing rope
 ::::::::::
 
 :::card{theme="error"}
-***If Hawlucha fainted on Ramos OR you used Protein on Hawlucha:***
+***If Hawlucha fainted on Ramos OR you used Protein on Hawlucha OR you plan to Protein skip in Laverre:***
 - PC heal Hawlucha
 - Use Protein on Hawlucha if you haven't yet
 - Shopping (left)
@@ -968,20 +966,18 @@ Use any remaining Sweet Hearts on Hawlucha (3 friendship per Sweet Heart)
 
 Get **Lucky Egg**
 
-:info[Heal Lucario if got hit by Acrobatics]{color=yellow}
+:::card{theme="info"}
+***Menu after getting Lucky Egg***
+- Heal Lucario if got hit by Acrobatics
+- Teach Fly to Hawlucha over Flying Press
+- Turn off Experience Share
+- Give Lucario Lucky Egg
+- Swap Hawlucha with Lucario
+- Fly to Coumarine
+:::
 
-Teach Fly to Hawlucha over Flying Press
-
-Turn off Experience Share
-
-Give Lucario Lucky Egg
-
-Swap Hawlucha with Lucario
-
-Fly to Coumarine
-
-If you haven't shopped yet, enter the center and shop
-
+:::card{theme="error"}
+***If you haven't shopped yet, enter the center and shop***
 ### Shopping (left):
 > #### Buy
 > - 11 Max Repels (^^)
@@ -989,6 +985,7 @@ If you haven't shopped yet, enter the center and shop
 > - 5 Full Heals (^)
 > - 2 Revive (v<)
 > - 16 Hyper Potions (^^)
+:::
 
 No Wind: xx:10, xx:30, xx:50 for 10 minutes
 
@@ -1013,7 +1010,7 @@ Pickup hidden **Power Plant Pass**
 :::::
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Croagunk]{info="Revenge does 42(44)" infoColor=blue}
-    - Swords Dance {info="Full Heal if confused" infoColor=blue}
+    - Swords Dance :info[Full Heal if confused]{color="blue"}
     - Low Sweep
  ::::
  ::::pokemon[Golbat]
@@ -1031,7 +1028,7 @@ Pickup hidden **Power Plant Pass**
     - Low Sweep
   ::::
   ::::pokemon[Golbat]
-    - Swords Dance {info="Full Heal if confused" infoColor=blue}
+    - Swords Dance :info[Full Heal if confused (or yolo)]{color="blue"}
     - Rock Tomb
     - _Give up on Me First_
   ::::
@@ -1192,9 +1189,10 @@ Pickup **Rare Candy**
     - Aura Sphere x2
  ::::
 :::::
+
 ### Shopping (right):
 > #### Buy
-> - 7 (MAX) Proteins **do not use them yet** (only 6 Proteins if used Protein on Hawlucha and did the corresponding Courmarine shop)
+> - MAX (6-7) Proteins **do not use them yet** (can skip on bad runs)
 
 :info[Heal if 106 (109) HP or below]{color=yellow}
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -443,28 +443,45 @@ Get double massage if possible
     - Swords Dance / Encore on Gust and die
  ::::
 :::::
+
 Deposit Farfetch’d
+
 :::::::trainer[Leader Korrina]
   :::::pokemon[Lucario]
-     - Swords Dance x2-3
-     - Karate Chop / Rock Smash (x2)
-   :::if{source="Hawlucha" condition="startingLevel=19"}
-     ::damage[Rock Smash +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=40 level=21 effectiveness=2 opponentLevel=22 stab=true  opponentStat=45 theme=error}
+    :::if{source="Hawlucha" condition="startingLevel=19 && atk=(16+/#/#)"}
+      - Swords Dance x2
+      - Karate Chop
+      ::damage[Karate Chop +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=50 level=21 effectiveness=2 opponentLevel=25 stab=true opponentStat=45 theme=error}
     :::
-   :::if{source="Hawlucha" condition="startingLevel=20"}
-     ::damage[Rock Smash +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=40 level=22 effectiveness=2 opponentLevel=22 stab=true  opponentStat=45 theme=error}
+    :::if{source="Hawlucha" condition="startingLevel=19 && atk=(15-/x/x)"}
+      - Swords Dance x3 (x2 if want to go for ranges)
+      - Karate Chop
+      ::damage[Karate Chop +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=50 level=21 effectiveness=2 opponentLevel=25 stab=true opponentStat=45 theme=error}
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20 && atk=(x/12+/#)"}
+      - Swords Dance x2
+      - Rock Smash (x2)
+      ::damage[Rock Smash +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true opponentStat=45 theme=error}
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20 && atk=(#/11-/x)"}
+      - Swords Dance x3 (x2 if want to go for ranges)
+      - Rock Smash
+      ::damage[Rock Smash +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true opponentStat=45 theme=error}
     :::
   :::::
+
   :::::pokemon[Lucario]
-     - Karate Chop / Rock Smash (x2)
     :::if{source="Hawlucha" condition="startingLevel=19"}
-     ::damage[Karate Chop +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=50 level=22 effectiveness=2 opponentLevel=22 stab=true  opponentStat=45 theme=error}
+      - Karate Chop
+      ::damage[Karate Chop +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=50 level=22 effectiveness=2 opponentLevel=25 stab=true opponentStat=45 theme=error}
     :::
-   :::if{source="Hawlucha" condition="startingLevel=20"}
-     ::damage[Karate Chop +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=50 level=23 effectiveness=2 opponentLevel=22 stab=true  opponentStat=45 theme=error}
+    :::if{source="Hawlucha" condition="startingLevel=20"}
+      - Rock Smash
+      ::damage[Rock Smash +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=40 level=23 effectiveness=2 opponentLevel=25 stab=true opponentStat=45 theme=error}
     :::
   :::::
 :::::::
+
 Equip Jaw Fossil
 
 Use a Repel

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -324,10 +324,12 @@ Register Bike
 
 Buy a dozen Soda Pops from the Waitress
 
-Pickup Hidden X Speed
+Pickup hidden X Speed
 
 Go to Geosenge center and catch Hawlucha with Luxury Balls.
   - If Hawlucha and Farfetch’d are full HP, weaken with Aerial Ace.
+  - _Full HP: 21.7% catch_
+  - _Half HP: 36.5% catch_
 
 :::::card{theme=warning}
   :::if{source="Hawlucha" condition="startingLevel=19"}
@@ -387,11 +389,19 @@ Swap Farfetch’d back to front
     :::
   :::::
   :::::pokemon[Tyrunt]{info="if Unburden, you will outspeed after 2 Rock Tombs with Oran Berry" infoColor=blue}
+    :::if{source="Hawlucha" condition="startingLevel=19"}
+      ::damage[Tyrunt Rock Tomb at L21 does]{source="Hawlucha" special=false offensive=false movePower=60 level=21 opponentLevel=25 stab=true opponentStat=55}
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20"}
+      ::damage[Tyrunt Rock Tomb at L22 does]{source="Hawlucha" special=false offensive=false movePower=60 level=22 opponentLevel=25 stab=true opponentStat=55}
+    :::
+
+    - _Heal with Soda Pop if you are dead to Rock Tomb unless faster from Unburden_
     :::if{source="Hawlucha" condition="atk=(x/26+/7-30) && startingLevel=19"}
       - Karate Chop
-      - If Karate Chop crit
+      - If Karate Chop crits
          - Karate Chop
-      - Else
+      - Otherwise
          - Swords Dance
          - Karate Chop
     :::
@@ -641,7 +651,13 @@ Head to the gym
     - Wing Attack
  ::::
 :::::
-:info[Teach Flying Press over Fling  at Lv28]{color=yellow}
+
+:::if{source="Hawlucha" condition="startingLevel=20 && atk=(x/x/15+)"}
+   :info[Don't teach Flying Press]{color="yellow"}
+:::
+:::if{source="Hawlucha" condition="startingLevel=20 && atk=(#/#/14-) || startingLevel=19"}
+   :info[Teach Flying Press over Fling  at Lv28]{color=yellow}
+:::
 
 Fight Dash first if you already meet the requirements to OHKO Heracross or will not meet them at a higher level
 
@@ -824,9 +840,15 @@ Pickup **TM47 Low Sweep**
 :::::::
 Go right after the first climbing rope
 :::::trainer[Pokémon Ranger Chaise]
- ::::pokemon[Simisage]{info="100% at 73+ attack" infoColor=red}
-    -  Flying Press
- ::::
+  ::::pokemon[Simisage]
+    :::if{source="Hawlucha" condition="startingLevel=20 && atk=(x/x/15+)"}
+      - Wing Attack x2
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20 && atk=(#/#/14-) || startingLevel=19"}
+      - Flying Press :info[100% at 73+ attack]{color="red"}
+    :::
+
+  ::::
 :::::
 :::::trainer[Pokémon Ranger Brooke]
  ::::pokemon[Roselia]
@@ -1100,13 +1122,14 @@ Pickup **Rare Candy**
     - Swords Dance x3
     - If Iron Defense on Turn 1 or 2
       - Shadow Claw, then finish setting up Swords Dance
+      - _If Shadow Claw crit kills Mawile, stop setting up Swords Dance and 2HKO Sylveon (Dazzling Gleam does ~50%)_
     - Aura Sphere (Shadow Claw if no Iron Defenses)
   ::::
   ::::pokemon[Mr. Mime]
     - Shadow Claw
   ::::
   ::::pokemon[Sylveon]{info="15/16 Range" infoColor=red}
-    - Shadow Claw
+    - Shadow Claw (x2)
     - If you miss the range and die
       - Send out Lapras
       - Perish Song

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -169,9 +169,10 @@ Deposit Squirtle
 > #### Buy 
 > - Swords Dance (vv)
 
-- At the grass after Lucario cutscene:
+At the grass after Lucario cutscene:
   - Repel
   - Teach Swords Dance over Fury Cutter (slot 2).
+
 :::::::trainer[Tierno]
   :::::pokemon[Corphish]
     :::if{source="Quacklin" condition="atk=(x/28+/x)"}
@@ -216,7 +217,7 @@ Pickup **Rare Candy** in the fountain at the castle.
 
 Run from Snorlax
 
-- At Trevor & Tierno fight:
+At Trevor & Tierno fight:
   - Repel (keep applied until done with Rhyhorn)
   - (Super) Potion if took damage on Corphish
   - Equip Berry Juice
@@ -323,11 +324,10 @@ Register Bike
 
 Buy a dozen Soda Pops from the Waitress
 
-_Optionally Pickup hidden X-Speed for greater Lucky Egg consistency_
-  - _Using X items increases Hawlucha’s friendship_
+Pickup Hidden X Speed
 
-Go to Geosenge centre and catch Hawlucha with Luxury Balls.
-  - If Hawlucha and Farfetch’d are full HP use Aerial Ace.
+Go to Geosenge center and catch Hawlucha with Luxury Balls.
+  - If Hawlucha and Farfetch’d are full HP, weaken with Aerial Ace.
 
 :::::card{theme=warning}
   :::if{source="Hawlucha" condition="startingLevel=19"}
@@ -432,7 +432,7 @@ Swap Hawlucha to the front of party
 
 Pickup hidden Protein
 
-_Optionally pickup X-Defense_
+_Optionally pickup X-Defense for friendship gain_
 
 Pickup hidden Ether
 
@@ -561,7 +561,7 @@ Use Iron
 
 Use HP Up
 
-Use PP Up if only got one massage and it was bad
+Use PP Up if both massages were bad
 
 :info[Heal to full with Soda Pop]{color=yellow}
 :::::::trainer[Pokémon Trainer Calem]
@@ -631,10 +631,10 @@ Head to the gym
  ::::pokemon[Throh]
     - Wing Attack
     :::if{source="Hawlucha" condition="startingLevel=19"}
-      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=26 opponentLevel=28 healthThreshold=104 opponentStat=53}
+      ::damage[+2 Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=26 opponentLevel=28 healthThreshold=104 opponentStat=53}
     :::
     :::if{source="Hawlucha" condition="startingLevel=20"}
-      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=27 opponentLevel=28 healthThreshold=104 opponentStat=53}
+      ::damage[+2 Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=27 opponentLevel=28 healthThreshold=104 opponentStat=53}
     :::
  ::::
  ::::pokemon[Machoke]
@@ -689,7 +689,7 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
   :::::
 :::::::
 
-- Heal with Soda Pop unless very high HP
+Heal with Soda Pop unless very high HP
 
 ::damage[Hawlucha Flying Press does]{source="Hawlucha" special=false offensive=false stab=true evs=10 movePower=80 level=29 opponentLevel=32 opponentStat=70}
 
@@ -843,6 +843,7 @@ Go right after the first climbing rope
  ::::
  ::::pokemon[Exeggutor]
     - Wing Attack
+   ::damage[+2 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=32 healthThreshold=104 combatStages=2 effectiveness=2 movePower=60 level=32 opponentLevel=31 stab=true opponentStat=55 theme=error}
    ::damage[Exeggutor’s Psyshock does]{source="Hawlucha" special=true offensive=false movePower=80 level=32 opponentLevel=31 stab=true opponentStat=48}
  ::::
 :::::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -455,11 +455,11 @@ Use a Repel
 :::::::
 :info[Use a Soda Pop if can die to Confusion (or Super Potion on Shadow Punch if going for +0 range)]{color=yellow}
 :::if{source="Hawlucha" condition="startingLevel=19"}
-::damage[Chimecho’s Confusion does at L24]{source="Hawlucha" special=true offensive=false movePower=50 level=24 opponentLevel=24 stab=true opponentStat=55}
+::damage[Chimecho’s Confusion does at L24]{source="Hawlucha" special=true offensive=false movePower=50 level=24 opponentLevel=24 stab=true effectiveness=2 opponentStat=55}
 ::damage[Golett’s Shadow Punch does at L24]{source="Hawlucha" special=false offensive=false movePower=60 level=24 opponentLevel=24 stab=true opponentStat=40}
 :::
 :::if{source="Hawlucha" condition="startingLevel=20"}
-::damage[Chimecho’s Confusion does at L25]{source="Hawlucha" special=true offensive=false movePower=50 level=25 opponentLevel=24 stab=true opponentStat=55}
+::damage[Chimecho’s Confusion does at L25]{source="Hawlucha" special=true offensive=false movePower=50 level=25 opponentLevel=24 stab=true effectiveness=2 opponentStat=55}
 ::damage[Golett’s Shadow Punch does at L25]{source="Hawlucha" special=false offensive=false movePower=60 level=25 opponentLevel=24 stab=true opponentStat=40}
 :::
 :::::trainer[Psychic Franz]
@@ -782,10 +782,10 @@ Go right after the first climbing rope
    - Teach Rock Tomb over Shadow Claw (slot 3)
 :::
 :::if{source="Hawlucha" condition="startingLevel=19"}
-::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=32 opponentLevel=30 stab=true opponentStat=44}
+::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=32 opponentLevel=30 stab=true effectiveness=2 opponentStat=44}
 ::::
 :::if{source="Hawlucha" condition="startingLevel=20"}
-::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=33 opponentLevel=30 stab=true opponentStat=44}
+::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=33 opponentLevel=30 stab=true effectiveness=2 opponentStat=44}
 :::
 ::damage[Take down does]{source="Hawlucha" special=false offensive=false movePower=90 level=33 opponentLevel=34 stab=false opponentStat=88}
 
@@ -1513,7 +1513,8 @@ Fly out of the forest
  ::::
 :::::
 
-:info{Heal to full}[color=yellow]
+:info[Heal to full]{color=yellow}
+
 Teach Shadow Claw over Aura Sphere (Slot 1)
 
 :::::trainer[Pokémon Trainer Calem]

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -48,10 +48,10 @@ _Updated and maintained by WaveWarrior_
 
 _notes by wartab_ [base doc](https://docs.google.com/document/d/1eI4u7X_p3weBLY8hAMuaF-LwcAtmqeT3YdLiwZPC0r4/edit)
 
-_8 Protein and 1 Protein Strat_ [base doc](https://pastebin.com/rahQFiqH)
+_8 Protein and 1 Protein Strat_ [pastebin](https://pastebin.com/rahQFiqH)
 
 :::card
-Set console date to 14th February and time to 23:03 (adapt for skill level)
+Set console date to 14th February and time to 23:04 (WR pace) or earlier
 :::
  
 
@@ -61,7 +61,7 @@ Open options and set
   - Text Speed Fast
   - Battle Effects: Off
   - Battle Style Set
-  - (Button Mode L = A)
+  - Button Mode L = A
 
 Pick Chespin
 
@@ -346,7 +346,7 @@ Go to Geosenge center and catch Hawlucha with Luxury Balls.
 
 :::::card{theme=warning}
   :::if{source="Hawlucha" condition="startingLevel=19"}
-####   - Swap Hawlucha to the front of the party
+####   - Swap Hawlucha to the front of the party and select Restore
 ####   - Heal Hawlucha if it got damaged
 ####   - Give 2 Rare Candies to Hawlucha
 ####   - Teach Encore over Aerial Ace (Slot 4)
@@ -354,13 +354,13 @@ Go to Geosenge center and catch Hawlucha with Luxury Balls.
 ####   - Swap Oran Berry to Hawlucha if holding it
   :::
   :::if{source="Hawlucha" condition="speed=~(x/x/12+) && startingLevel=19"}
- ####  - Pick up hidden X-Speed
+ ####  - Pick up hidden **X-Speed** if you didn't yet
   :::
   :::if{source="Hawlucha" condition="speed=(11-/x/x) && startingLevel=19"}
   ####  - Reset for another Hawlucha
   :::  
   :::if{source="Hawlucha" condition="startingLevel=20"}
-####   - Swap Hawlucha to the front of the party
+####   - Swap Hawlucha to the front of the party and select Restore
 ####   - Heal Hawlucha if it got damaged
 ####   - Give 2 Rare Candies to Hawlucha
 ####   - Teach Swords Dance over Roost (Slot 2)
@@ -368,7 +368,7 @@ Go to Geosenge center and catch Hawlucha with Luxury Balls.
 ####   - Swap Oran Berry to Hawlucha if holding it
   :::
   :::if{source="Hawlucha" condition="speed=~(x/24+/1+) && startingLevel=20"}
- ####  - Pick up hidden X-Speed
+ ####  - Pick up hidden **X-Speed** if you didn't yet
   :::
   :::if{source="Hawlucha" condition="speed=(4-/x/x) && startingLevel=20"}
 ####    - Reset for another Hawlucha
@@ -411,9 +411,9 @@ Swap Farfetch’d back to front
     - _Heal with Soda Pop if you are dead to Rock Tomb unless faster from Unburden_
     :::if{source="Hawlucha" condition="atk=(x/26+/7-30) && startingLevel=19"}
       - Karate Chop
-      - If Karate Chop crits
+      - _If Karate Chop crits_
          - Karate Chop
-      - Otherwise
+      - _Otherwise_
          - Swords Dance
          - Karate Chop
     :::
@@ -437,9 +437,9 @@ Swap Farfetch’d back to front
     :::if{source="Hawlucha" condition="atk=(x/16+/25-) && startingLevel=20"}
           
       - Rock Smash
-      - If Rock Smash crits AND gets defense drop
+      - _If Rock Smash crits AND gets defense drop_
         - Rock Smash
-      - Otherwise
+      - _Otherwise_
         - Swords Dance
         - Rock Smash
     :::
@@ -528,7 +528,7 @@ Use a Repel
      - Swords Dance x2
      - Wing Attack
   :::::
-  :::::pokemon[Helioptile]{info="Has Quick Attack"}
+  :::::pokemon[Helioptile]{info="Has Quick Attack" infoColor="blue"}
      :::if{source="Hawlucha" condition="startingLevel=19"}
       - Karate Chop
       ::damage[Heliptile QA does at 23]{source="Hawlucha" special=false offensive=false movePower=40 level=23 opponentLevel=25 stab=true opponentStat=25}
@@ -549,7 +549,7 @@ Use a Repel
     :::
   :::::  
 :::::::
-:info[Use a Soda Pop if can die to Confusion (or Super Potion on Shadow Punch if going for +0 range)]{color=yellow}
+:info[Use a Soda Pop if can die to Confusion]{color=yellow}
 :::if{source="Hawlucha" condition="startingLevel=19"}
 ::damage[Chimecho’s Confusion does at L24]{source="Hawlucha" special=true offensive=false movePower=50 level=24 opponentLevel=24 stab=true effectiveness=2 opponentStat=55}
 ::damage[Golett’s Shadow Punch does at L24]{source="Hawlucha" special=false offensive=false movePower=60 level=24 opponentLevel=24 stab=true opponentStat=40}
@@ -601,7 +601,7 @@ Use **PP Up**
      - Encore (if no Fake Out/Light Screen, the run is over, heal until Light Screen?)
      - Swords Dance x2
      - Encore
-     - Swords Dance
+     - Swords Dance unless already at +6
      - Wing Attack x2
     :::
     :::if{source="Hawlucha" condition="speed=~(x/24+/#) && startingLevel=20"}
@@ -617,7 +617,7 @@ Use **PP Up**
      - Encore (if no Fake Out/Light Screen, the run is over, heal until Light Screen?)
      - Swords Dance x2
      - Encore
-     - Swords Dance
+     - Swords Dance unless already at +6
      - Wing Attack x2
     :::
   :::::
@@ -752,7 +752,7 @@ Head to the gym
 Pickup **TM47 Low Sweep**
 :::::trainer[Successor Korrina]
  ::::pokemon[Lucario]
-    - [Mega Evolve] Metal Sound x2 
+    - **[Mega Evolve]** Metal Sound x2 
  ::::
 :::::
 :::::card
@@ -910,7 +910,7 @@ Go right after the first climbing rope
     :::::pokemon[Jumpluff]
       - Swords Dance
       - Wing Attack
-      - If Hawlucha dies 
+      - _If Hawlucha dies _
         - Switch to Lucario
         - Rock Tomb
     :::::     
@@ -952,10 +952,9 @@ Go right after the first climbing rope
 ::::::::::
 
 :::card{theme="error"}
-***If Hawlucha fainted on Ramos OR you used Protein on Hawlucha OR you plan to Protein skip in Laverre:***
-- PC heal Hawlucha
-- Use Protein on Hawlucha if you haven't yet
-- Shopping (left)
+***If you are NOT doing 8 Protein strat:***
+- **If Hawlucha died on Ramos**: PC heal and give it the Protein if you haven't yet
+### Shopping (left):
 > #### Buy
 > - 11 Max Repels (^^)
 > - 1 Escape Ropte (^^^)
@@ -979,7 +978,7 @@ Get **Lucky Egg**
 :::
 
 :::card{theme="error"}
-***If you haven't shopped yet, enter the center and shop***
+***If you are doing 8 Protein strat:***
 ### Shopping (left):
 > #### Buy
 > - 11 Max Repels (^^)
@@ -1126,7 +1125,7 @@ Pickup hidden **Power Plant Pass**
 :::::
 :info[Heal to full]{color=yellow}
 
-Use Protein on Lucario
+Use **Protein** on Lucario
 
 Teach Shadow Claw over Bone Rush (Slot 4)
 
@@ -1148,23 +1147,23 @@ Pickup **Rare Candy**
 :::::trainer[Leader Valerie]
   ::::pokemon[Mawile]
     - Swords Dance x3 (adapt if Mawile uses Iron Defense)
-    - If Iron Defense on Turn 1 or 2
+    - _If Iron Defense on Turn 1 or 2_
       - Shadow Claw
       - Finish setting up Swords Dance
       - Aura Sphere
       - _If Shadow Claw crit kills Mawile, stop setting up Swords Dance and 2HKO Sylveon (Dazzling Gleam does 54-63 (64))_
-    - If Iron Defense Turn 3
+    - _If Iron Defense Turn 3_
       - Rock Tomb (crit is 9/16 range)
       - Aura Sphere (6/16 range from full)
-    - If no Iron Defense
+    - _If no Iron Defense_
       - Shadow Claw
   ::::
   ::::pokemon[Mr. Mime]
     - Shadow Claw
   ::::
   ::::pokemon[Sylveon]
-    - Shadow Claw (x2)  :info[15/16 range with 0 Protein, 16/16 with 1 Protein]{color="blue"}
-    - If you miss the range and die
+    - Shadow Claw (x2)  :info[Guaranteed with 1 Protein, 15/16 range with 0 Protein]{color="blue"}
+    - _If you miss the range and die_
       - Send out Lapras
       - Perish Song
       - Revive Lucario
@@ -1204,10 +1203,10 @@ Max Repel → Keep applied until off of Mamoswine
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Golbat]
     - Swords Dance
-    - If not hit by Acrobatics
+    - _If not hit by Acrobatics_
        - Swords Dance again
        - Shadow Claw
-    - Otherwise
+    - _Otherwise_
        - Rock Tomb
  ::::
  ::::pokemon[Manectric]
@@ -1231,19 +1230,19 @@ Pickup **Rare Candy**
 :::::trainer[Pokémon Trainer Calem]
  ::::pokemon[Meowstic]
     - Swords Dance
-    - If Fake Out
+    - _If Fake Out_
       - Swords Dance x2
       - Shadow Claw
-    - Otherwise
+    - _Otherwise_
       - Shadow Claw
  ::::
  ::::pokemon[Delphox]
     - Shadow Claw
  ::::
  ::::pokemon[Jolteon]{info="Quick Attack can do 7/(8), Discharge 63/(64)" infoColor=blue}
-    - If used 2 Swords Dance (Fake Out)
+    - _If used 2 Swords Dance (Fake Out)_
       - Shadow Claw
-    - Otherwise (No Fake Out)
+    - _Otherwise (No Fake Out)_
       - Rock Tomb
       - Shadow Claw
  ::::
@@ -1334,7 +1333,7 @@ _If Liepard gives you level 51, fight it first, then use all Rare Candies and Pr
     - Switch to Lapras
     - Rock Smash
     - _If no Outrage_ 
-      - _Switch to Hawlucha, revive Lapras and try again_
+      - Switch to Hawlucha, revive Lapras and try again
       - _Yolo strat if full HP: just send in Lucario, Earthquake is 7/16 to kill from full_
     - Switch to Lucario
     - Swords Dance
@@ -1466,7 +1465,7 @@ PC Heal Lucario and Lapras:
 :::::
 :info[Heal if at 88 (90) HP or lower]{color=yellow}
 :::::trainer[Team Flare Lysandre]
- ::::pokemon[Mienfoo]
+ ::::pokemon[Mienshao]
     - Close Combat
  ::::
  ::::pokemon[Pyroar]
@@ -1474,13 +1473,15 @@ PC Heal Lucario and Lapras:
  ::::
  ::::pokemon[Gyarados]
     - Switch to Lapras
-    - Rock Smash
-    - _If Lucario is not full HP and no Outrage_
+    - _If Lapras does not get crit_
+      - Heal Lucario to full (Rock Smash if already full)
+      - Lapras dies, swap in Lucario
+    - _If Lapras gets crit and Lucario is NOT full HP_
       - Swap in Squirtle
-      - Heal Lucario to full (Squirtle dies)
-      - Switch in Lucario
-    - _Otherwise_
-      - Switch in Lucario
+      - Heal Lucario to full
+      - Squirtle dies, swap in Lucario
+    - _If Lapras gets crit and Lucario is full HP_
+      - Swap in Lucario
     - Swords Dance
     - Rock Tomb
  ::::
@@ -1488,6 +1489,9 @@ PC Heal Lucario and Lapras:
     - Close Combat
  ::::
 :::::
+
+:info[Heal to full if hit by Earthquake]{color="yellow"}
+
 :::::trainer[Team Flare Double 1]
  ::::pokemon[Liepard]
     - Aura Sphere
@@ -1508,7 +1512,7 @@ PC Heal Lucario and Lapras:
 
 :info[Heal to full]{color="yellow"}
 
-Use PP Up on Close Combat if haven't yet
+Use **PP Up** on Close Combat if you haven't yet
 
 :::::trainer[Team Flare Double 3]
  ::::pokemon[Scrafty]
@@ -1596,12 +1600,12 @@ Max Repel
     - Rock Tomb
  ::::
  ::::pokemon[Crawdaunt]
-    - If can tank 100 / (102) and desperate for time save
+    - _If can tank 100 / (102) and desperate for time save_
       - Swords Dance
     - Aura Sphere
  ::::
- ::::pokemon[Roserade]{info="Petal Dance can do 48" infoColor=blue}
-    - If didn’t Swords Dance yet
+ ::::pokemon[Roserade]{info="Petal Dance can do 46 (48)" infoColor=blue}
+    - _If didn’t Swords Dance yet_
       - Swords Dance
     - Close Combat
     - _Give up on Extreme Speed_
@@ -1615,8 +1619,13 @@ Free Heal
     - Close Combat
  ::::
  ::::pokemon[Florges]
-    - **If no Static**: Swords Dance + Close Combat
-    - **If Static**: Swords Dance + Full Restore + Close Combat (you die if fully paralyzed on SD turn into Moonblast)
+    - _If no Static_
+      - Swords Dance
+      - Close Combat
+    - _If Static_
+      - Swords Dance (you die if fully paralyzed into Moonblast)
+      - Full Restore
+      - Close Combat 
  ::::
  ::::pokemon[Aerodactyl]
     - Rock Tomb
@@ -1642,7 +1651,7 @@ Bike to the forest
 
 Fly out of the forest
 
-:::::trainer[Ace Trainer Imelda]
+:::::trainer[Ace Trainer Imelda (pink platform)]
  ::::pokemon[Sneasel]
     - Aura Sphere
  ::::
@@ -1651,8 +1660,7 @@ Fly out of the forest
  ::::
 ::::: 
 :info[**Pink x2**]{color=pink}
-:info[**Go to blue platform**]{color=blue}
-:::::trainer[Ace Trainer Viktor]
+:::::trainer[Ace Trainer Viktor (blue platform)]
  ::::pokemon[Delibird]
     - Aura Sphere
  ::::
@@ -1662,7 +1670,7 @@ Fly out of the forest
 :::::
 :info[**Blue x3**]{color=blue}
 :info[**Pink x3**]{color=pink}
-:::::trainer[Ace Trainer Shannon]
+:::::trainer[Ace Trainer Shannon (green platform)]
  ::::pokemon[Cryogonal]
     - Rock Tomb
  ::::
@@ -1673,7 +1681,7 @@ Fly out of the forest
     - Rock Tomb
  ::::
 :::::
-:::::trainer[Ace Trainer Theo]
+:::::trainer[Ace Trainer Theo (yellow platform)]
  ::::pokemon[Beartic]
     - Aura Sphere
  ::::
@@ -1732,9 +1740,9 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
     - Shadow Claw
   ::::
   ::::pokemon[Jolteon]{info="Speed tie without Steadfast boost" infoColor=red}
-    - With Swords Dance
+    - _With Swords Dance_
       - Shadow Claw
-    - With X-Attack
+    - _With X-Attack_
       - Close Combat
   ::::
   ::::pokemon[Altaria]
@@ -1804,10 +1812,10 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
     - Close Combat
  ::::
 :::::
-Deposit all Pokémon
-
 
 PC Heal Lucario
+
+Deposit all Pokémon
 
 Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
 
@@ -1815,7 +1823,7 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
  ::::pokemon[Pyroar]
     - Swords Dance 
     - _If Noble Roared_
-      - Swords Dance
+      - Swords Dance once more
     - _If Burnt_
       - Full Restore
     - Close Combat
@@ -1857,7 +1865,7 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
 :::::
 :info[Heal to full if 120- HP (168- if doing safe Drasna)]{color=yellow}
 
-:::::trainer[Elite Four Drasna]
+:::::trainer[Elite Four Drasna (safe with 8 Proteins)]
  ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
     - Swords Dance x2 
     - _If at 24 HP or less_
@@ -1871,11 +1879,11 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
     - Close Combat :info[Shadow Claw 15/16]{color="red"}
  ::::
  ::::pokemon[Altaria]
-    - Shadow Claw :info[Rock Tomb if less than 8 Proteins]{color="red"}
+    - Shadow Claw :info[Rock Tomb if used less than 8 Proteins on Lucario]{color="red"}
  ::::
 :::::
 
-:::::trainer[Elite Four Drasna (safe)]
+:::::trainer[Elite Four Drasna (always safe)]
  ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
     - Swords Dance x3
     - _If at 24 HP or less_
@@ -1934,7 +1942,7 @@ Ether Close Combat
     - _If miss, you are at full HP and Aurorus used Reflect_
       - Swords Dance
       - _If you got hit by Thunder_
-        - [Meva Evolve] Rock Tomb
+        - **[Mega Evolve]** Rock Tomb
       - _If Thunder missed or went for Light Screen_
         - Swords Dance 
         - Rock Tomb
@@ -1954,7 +1962,7 @@ Ether Close Combat
 
 :::::trainer[Champion Diantha (safer version)]
  ::::pokemon[Hawlucha]
-    - [Mega Evolve] Swords Dance 
+    - **[Mega Evolve]** Swords Dance 
     - Shadow Claw
  ::::
  ::::pokemon[Goodra]
@@ -1978,6 +1986,6 @@ Ether Close Combat
 
 :::::trainer[Trainer AZ]
  ::::pokemon[Torkoal]
-    - Swords Dance until dead
+    - Swords Dance x2
  ::::
 :::::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1258,10 +1258,9 @@ GYM Puzzle
 
 :info[Heal if 28 (29) or lower]{color=yellow}
 
-_If already level 51_
-  - Pokemon Menu -> Lucario Restore
-    - Use 2 Rare Candies 
-    - 6 Proteins
+_If already level 51: Pokemon Menu -> Lucario Restore_
+  - _Use 2 Rare Candies_
+  - _6 Proteins_
 
 Fly to the center of Lumiose City
 
@@ -1575,7 +1574,7 @@ Free Heal
  ::::
  ::::pokemon[Florges]
     - **If no Static**: Swords Dance + Close Combat
-    - **If Static** Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
+    - **If Static**: Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
  ::::
  ::::pokemon[Aerodactyl]
     - Rock Tomb
@@ -1643,7 +1642,7 @@ Fly out of the forest
 :info[**Green x3**]{color=green}
 :::::trainer[Leader Wulfric]
 
-  If going for X Attack Calem fight, need 4 Close Combats after this fight.
+  _If going for X Attack Calem fight, need 4 Close Combats after this fight_
 
   ::::pokemon[Abomasnow]
     - Aura Sphere

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -940,7 +940,20 @@ Go right after the first climbing rope
 :::::::
 ::::::::::
 
-If Hawlucha fainted, PC heal Hawlucha
+:::card{theme="error"}
+***If Hawlucha fainted on Ramos OR you used Protein on Hawlucha:***
+- PC heal Hawlucha
+- Use Protein on Hawlucha if you haven't yet
+- Shopping (left)
+> #### Buy
+> - 11 Max Repels (^^)
+> - 1 Escape Ropte (^^^)
+> - 11 Full Heals (^)
+> - 3 Revives (v<)
+> - MAX Hyper Potions (^^) (Should be 19 with standard shopping)
+:::
+
+Use any remaining Sweet Hearts on Hawlucha
 
 Get **Lucky Egg**
 
@@ -956,7 +969,8 @@ Swap Hawlucha with Lucario
 
 Fly to Coumarine
 
-:::card
+If you haven't shopped yet, enter the center and shop
+
 ### Shopping (left):
 > #### Buy
 > - 11 Max Repels (^^)
@@ -964,7 +978,6 @@ Fly to Coumarine
 > - 5 Full Heals (^)
 > - 2 Revive (v<)
 > - 16 Hyper Potions (^^)
-:::
 
 No Wind: xx:10, xx:30, xx:50 for 10 minutes
 
@@ -1169,7 +1182,7 @@ Pickup **Rare Candy**
 :::::
 ### Shopping (right):
 > #### Buy
-> - 7 Proteins **do not use them yet**
+> - 7 (MAX) Proteins **do not use them yet** (only 6 Proteins if used Protein on Hawlucha and did the corresponding Courmarine shop)
 
 :info[Heal if 106 (109) HP or below]{color=yellow}
 
@@ -1269,11 +1282,11 @@ GYM Puzzle
 
 _If already level 51: Pokemon Menu -> Lucario Restore_
   - _Use 2 Rare Candies_
-  - _7 Proteins_
+  - _Use all Proteins_
 
 Fly to the center of Lumiose City
 
-Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Proteins
+_If Liepard gives you level 51, fight it first, then use all Rare Candies and Proteins, then fight Scrafty. This should only happen with a good bit of exp from optionals._
 
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Scrafty]{info="5/16 range at L50, 14/16 at L53" infoColor=red}
@@ -1290,7 +1303,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
 :::::
 - Before entering the bookcase
   - Use 2 Rare Candies
-  - Use all 7 Protein
+  - Use all Protein
   - Heal if 90 or less HP
  
 :::::trainer[Team Flare Lysandre]

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -586,9 +586,17 @@ Head to the gym
 :::::trainer[Roller Skater Kate]
  ::::pokemon[Meditite]
     - Wing Attack
+    ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=57 theme=error effectiveness=2 evs=16 movePower=60 level=26 opponentLevel=28 stab=true opponentStat=38}
+  
  ::::
  ::::pokemon[Mienfoo]
     - Wing Attack 
+    :::if{source="Hawlucha" condition="startingLevel=19"}
+      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error effectiveness=2 stab=true evs=16 movePower=60 level=26 opponentLevel=28 healthThreshold=66 opponentStat=31}
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20"}
+      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error effectiveness=2 stab=true evs=16 movePower=60 level=27 opponentLevel=28 healthThreshold=66 opponentStat=31}
+    :::
  ::::
 :::::
 :::::trainer[Roller Skater Shun]
@@ -598,6 +606,12 @@ Head to the gym
  ::::
  ::::pokemon[Throh]
     - Wing Attack
+    :::if{source="Hawlucha" condition="startingLevel=19"}
+      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=26 opponentLevel=28 healthThreshold=104 opponentStat=53}
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20"}
+      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=27 opponentLevel=28 healthThreshold=104 opponentStat=53}
+    :::
  ::::
  ::::pokemon[Machoke]
     - Wing Attack
@@ -623,8 +637,17 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
 :::::::
 :::::::trainer[Roller Skater Rolanda]
   :::::pokemon[Sawk]
+    :::if{source="Hawlucha" condition="startingLevel=19 && speed=(0+/11-/x) || startingLevel=20 && speed=(30-/2-/x)"}
+      - Slower than Sawk after one Low Sweep
+    :::
      - Swords Dance
      - Wing Attack
+     :::if{source="Hawlucha" condition="startingLevel=19"}
+      ::damage[Sawk Low Sweep does at L27]{source="Hawlucha" special=false offensive=false effectiveness=0.5 stab=true evs=10 movePower=65 level=27 opponentLevel=27 opponentStat=82}
+    :::
+    :::if{source="Hawlucha" condition="startingLevel=20"}
+      ::damage[Sawk Low Sweep does at L28]{source="Hawlucha" special=false offensive=false effectiveness=0.5 stab=true evs=10 movePower=65 level=28 opponentLevel=27 opponentStat=82}
+    :::
   :::::
   :::::pokemon[Hariyama]
     :::if{source="Hawlucha" condition="atk=(x/25+/7+) && startingLevel=19"}
@@ -641,6 +664,12 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
      :::
   :::::
 :::::::
+
+- Heal with Soda Pop unless very high HP
+
+::damage[Hawlucha Flying Press does]{source="Hawlucha" special=false offensive=false stab=true evs=10 movePower=80 level=29 opponentLevel=32 opponentStat=70}
+
+
 :::::::trainer[Leader Korrina]{info="Important: Remember if you X-Attack here or not" infoColor=yellow}
   :::::pokemon[Mienfoo]
     :::if{source="Hawlucha" condition="atk=(x/x/20+) && startingLevel=19"}
@@ -1105,7 +1134,7 @@ Max Repel → Keep applied until off of Mamoswine
 :::::
 Pickup **PP Up** if had to use the other one
   - You can pick it up anyway for safety 
-:info[Safety usages are marked in Gray]{color=gray}
+:info[Safety usages are marked in Green]{color=green}
 
 Heal to full
 
@@ -1223,12 +1252,18 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Aura Sphere
  ::::
 :::::
+
+- Go Up-Left
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Swalot]{info="+2 Spit Up does 32/(33)" infoColor=blue}
     - Swords Dance x2 (x3 if Swalot is still Stockpiled)
     - Shadow Claw
  ::::
 :::::
+
+- Take teleporter
+
 :::::trainer[Team Flare Aliana]
  ::::pokemon[Mightyena]
     - Aura Sphere
@@ -1237,6 +1272,10 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Aura Sphere x2
  ::::
 :::::
+
+- Take left teleporter
+- Go Up, Right, Down
+
 :::::trainer[Team Flare Grunt]{info="Remeber HP After" infoColor=pink}
  ::::pokemon[Liepard]
     - Aura Sphere
@@ -1251,6 +1290,8 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
 
 :info[Heal to full if 66 (68) HP or less]{color=yellow}
 
+- Run Up-Right
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Houndoom]
     - Aura Sphere
@@ -1260,13 +1301,20 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Close Combat 
  ::::
 :::::
+
+- Go Right, Right, (Dodge Spinner) Down, Right-Down
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Golbat]{info="Acrobatics does 64/(66)" infoColor=blue}
     - Swords Dance
     - Rock Tomb
  ::::
 :::::
+
 :info[Heal to full if 66/(68) or less]{color=yellow}
+
+- Take Teleporter
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Toxicroak]
     - Swords Dance 
@@ -1276,6 +1324,9 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Aura Sphere
  ::::
 :::::
+
+- Run Right through door
+
 :::::trainer[Team Flare Mable]
  ::::pokemon[Houndoom]
     - Aura Sphere
@@ -1284,6 +1335,10 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Aura Sphere
  ::::
 :::::
+
+- Run Left through door
+- Go Down, Right-Down, Up-Left
+
 :::::trainer[Team Flare Xerosic]
  ::::pokemon[Crobat]{info="Air Slash does 36/(37)" infoColor=blue}
     - Swords Dance 
@@ -1398,7 +1453,7 @@ Catch Xerneas with Master Ball
  ::::
  ::::pokemon[Honchkrow]
     - Swords Dance 
-    - Rock Tomb :info[Close Combat]{color=gray}
+    - Rock Tomb :info[Close Combat]{color=green}
  ::::
  ::::pokemon[Gyarados]
     - Close Combat
@@ -1463,7 +1518,7 @@ Free Heal
     - **If Static** Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
  ::::
  ::::pokemon[Aerodactyl]
-    - Rock Tomb :info[Close Combat if did safe Trevor]{color=gray}
+    - Rock Tomb :info[Close Combat if did safe Trevor]{color=green}
  ::::
 :::::
 :::::trainer[Pokémon Trainer Trevor (safe)]
@@ -1569,7 +1624,6 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
       - X Attack
     - Otherwise
       - Swords Dance (again if get Fake Out)
-
     - Shadow Claw
  ::::
  ::::pokemon[Delphox]
@@ -1661,7 +1715,6 @@ Buy Full Restores (>) if none left
       - Swords Dance
     - If Burnt
       - Full Restore
-      - _Full Restore on Talonflame instead if 24 - 34 HP left (experimental)_
     - Close Combat
  ::::
  ::::pokemon[Talonflame]{info="Quick Attack does 17-19 (20)" infoColor=blue}
@@ -1715,7 +1768,7 @@ Buy Full Restores (>) if none left
     - Close Combat
  ::::
  ::::pokemon[Altaria]
-    - Rock Tomb :info[Close Combat]{color=gray}
+    - Rock Tomb :info[Close Combat]{color=green}
  ::::
 :::::
 Heal to full
@@ -1753,7 +1806,7 @@ Ether Close Combat
     - Close Combat
  ::::
  ::::pokemon[Aurorus]
-    - Rock Tomb :info[Close Combat if you took no damage]{color=gray}
+    - Rock Tomb :info[Close Combat if you took no damage]{color=green}
     - If miss, you are at full HP and Aurorus used Reflect
       - Swords Dance
       - If you got hit by Thunder

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -871,28 +871,29 @@ Go right after the first climbing rope
 ::damage[Take down does]{source="Hawlucha" special=false offensive=false movePower=90 level=33 opponentLevel=34 evs=10 stab=false opponentStat=88}
 
 ::::::::::if{source="Hawlucha" condition="speed=~(10-/x/x) && startingLevel=20 || speed=~(18-/x/x) && startingLevel=19"}
-:::::::trainer[Leader Ramos (without Lucario)]
-  :::::pokemon[Jumpluff]
-     - Swords Dance
-     - Wing Attack
-     - If Hawlucha dies 
-       - Switch to Lucario
-       - Rock Tomb
-  :::::     
-  :::::pokemon[Gogoat]
-    :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
+  :::::::trainer[Leader Ramos (without Lucario)]
+    :::::pokemon[Jumpluff]
+      - Swords Dance
+      - Wing Attack
+      - If Hawlucha dies 
+        - Switch to Lucario
+        - Rock Tomb
+    :::::     
+    :::::pokemon[Gogoat]
+      :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
+        - Wing Attack (Low Sweep if Lucario)
+      :::
+      :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
+        - Flying Press (Low Sweep if Lucario)
+      :::
+    :::::
+    :::::pokemon[Weepinbell]
       - Wing Attack (Low Sweep if Lucario)
-    :::
-    :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
-      - Flying Press (Low Sweep if Lucario)
-    :::
-  :::::
-  :::::pokemon[Weepinbell]
-    - Wing Attack (Low Sweep if Lucario)
 
-  :::::
-:::::::
+    :::::
+  :::::::
 ::::::::::
+
 ::::::::::if{source="Hawlucha" condition="speed=(10-/x/x) && startingLevel=20 || speed=(18-/x/x) && startingLevel=19"}
 :::::::trainer[Leader Ramos (with Lucario)]
   :::::pokemon[Jumpluff]
@@ -976,18 +977,20 @@ Pickup hidden **Power Plant Pass**
     - Low Sweep (x2)
  ::::
 :::::
+
 :::::trainer[Team Flare Grunt]
- ::::pokemon[Scraggy]
+  ::::pokemon[Scraggy]
     - Low Sweep
- ::::
- ::::pokemon[Golbat]
+  ::::
+  ::::pokemon[Golbat]
     - Swords Dance
     - Rock Tomb
- ::::
-
-Give up on Me First, heal if necessary
-
+    - _Give up on Me First_
+  ::::
 :::::
+
+:info[Heal if Necessary]{color="yellow"}
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Golbat]{info="Wing Attack does 27(29)" infoColor=blue}
     - Swords Dance
@@ -1055,9 +1058,8 @@ Give up on Me First, heal if necessary
 :::::
 :::::trainer[Poké Fan Lydie (Elevator 2)]
  ::::pokemon[Plusle]
-    - Low Sweep
-      - Teach Aura Sphere over Low Sweep (Slot 1)
-    - If already taught Aura Sphere, use Bone Rush.
+    - Low Sweep (Bone Rush if already taught Aura Sphere)
+    - _Teach Aura Sphere over Low Sweep (Slot 1)_
  ::::
 :::::
 :info[Heal if less than 40 HP]{color=yellow}
@@ -1081,39 +1083,41 @@ Teach Shadow Claw over Bone Rush (Slot 4)
 
 Max Repel (drop it in the gym, unless feeling very confident about movement)
 :::::trainer[Pokémon Trainer Calem]
- ::::pokemon[Meowstic]
+  ::::pokemon[Meowstic]
     - X-Attack
     - Shadow Claw
- ::::
- ::::pokemon[Delphox]
+  ::::
+  ::::pokemon[Delphox]
     - Shadow Claw
- ::::
- ::::pokemon[Absol]{info="2/16 range with Light Screen" infoColor=red}
+  ::::
+  ::::pokemon[Absol]{info="2/16 range with Light Screen" infoColor=red}
     - Aura Sphere (x2 if Light Screen)
- ::::
+  ::::
 :::::
 Pickup **Rare Candy**
 :::::trainer[Leader Valerie]
- ::::pokemon[Mawile]
+  ::::pokemon[Mawile]
     - Swords Dance x3
     - If Iron Defense on Turn 1 or 2
-       - Shadow Claw, then finish using Swords Dance
+      - Shadow Claw, then finish setting up Swords Dance
     - Aura Sphere (Shadow Claw if no Iron Defenses)
- ::::
- ::::pokemon[Mr. Mime]
+  ::::
+  ::::pokemon[Mr. Mime]
     - Shadow Claw
- ::::
- ::::pokemon[Sylveon]{info="15/16 Range" infoColor=red}
+  ::::
+  ::::pokemon[Sylveon]{info="15/16 Range" infoColor=red}
     - Shadow Claw
     - If you miss the range and die
-       - Send out Lapras
-       - Perish Song
-       - Revive Lucario
-       - Heal Lucario
-       - Perish Song
- ::::
+      - Send out Lapras
+      - Perish Song
+      - Revive Lucario
+      - Heal Lucario
+      - Perish Song
+  ::::
 :::::
+
 :info[Heal if 34 (36)]{color=yellow}
+
 :::::trainer[Team Flare Admin]
  ::::pokemon[Scraggy]
     - Aura Sphere
@@ -1230,10 +1234,11 @@ GYM Puzzle
 :::::
 
 :info[Heal if 28 (29) or lower]{color=yellow}
-_If already level 51_ 
-   - From the Restore menu
-   - Use 2 Rare Candies 
-   - 6 Proteins
+
+_If already level 51_
+  - Pokemon Menu -> Lucario Restore
+    - Use 2 Rare Candies 
+    - 6 Proteins
 
 Fly to the center of Lumiose City
 
@@ -1249,7 +1254,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Liepard]
     - Aura Sphere
-      - Give up on Heal Pulse
+    - _Give up on Heal Pulse_
  ::::
 :::::
 - Before entering the bookcase
@@ -1257,7 +1262,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
   - Use all 6 Protein
   - Heal if 90 or less HP
  
- :::::trainer[Team Flare Lysandre]
+:::::trainer[Team Flare Lysandre]
  ::::pokemon[Mienfoo]
     - Aura Sphere
  ::::
@@ -1307,7 +1312,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
  ::::
  ::::pokemon[Mightyena]
     - Aura Sphere
-    - Teach Close Combat over Shadow Claw (Slot 4)
+    - _Teach Close Combat over Shadow Claw (Slot 4)_
  ::::
 :::::
 
@@ -1326,6 +1331,8 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Close Combat 
  ::::
 :::::
+
+:info[Heal to full if 64 (66) HP or less]{color=yellow}
 
 - Go Right, Right, (Dodge Spinner) Down, Right-Down
 
@@ -1373,13 +1380,15 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Close Combat
  ::::
 :::::
-- Fly to Geosenge Town
-- PC Heal Lucario and Lapras
-   - Swap Lucario and Chespin
-   - Swap Lucario and Chespin
-   - Swap Lapras and Chespin
-   - Withdraw everything
-   - Withdraw everything (remember Lapras’ spot)
+
+Fly to Geosenge Town
+
+PC Heal Lucario and Lapras:
+  - Swap Lucario and Chespin
+  - Swap Lucario and Chespin
+  - Swap Lapras and Chespin
+  - Withdraw everything (remember Lapras’ spot)
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Manectric]
     - Aura Sphere
@@ -1426,11 +1435,14 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
  ::::
  ::::pokemon[Manectric]{info="Discharge does 49 (51)" infoColor=blue}
     - Aura Sphere
-    - Give up on Dragon Pulse
+    - _Give up on Dragon Pulse_
  ::::
 :::::
-- Heal to full
-- Use PP Up(s) on Close Combat if haven't yet
+
+:info[Heal to full]{color="yellow"}
+
+Use PP Up(s) on Close Combat if haven't yet
+
 :::::trainer[Team Flare Double 3]
  ::::pokemon[Scrafty]
     - Aura Sphere
@@ -1485,7 +1497,7 @@ Catch Xerneas with Master Ball
 :::::
 Fly to Anistar
 
-Heal to full
+:info[Heal to full]{color="yellow"}
 
 Max Repel
 :::::trainer[Pokémon Professor Sycamore]{info="Remember HP after" infoColor=pink}
@@ -1543,7 +1555,7 @@ Free Heal
     - **If Static** Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
  ::::
  ::::pokemon[Aerodactyl]
-    - Rock Tomb :info[Close Combat if did safe Trevor]{color=green}
+    - Rock Tomb
  ::::
 :::::
 :::::trainer[Pokémon Trainer Trevor (safe)]
@@ -1555,8 +1567,7 @@ Free Heal
     - Close Combat
  ::::
  ::::pokemon[Aerodactyl]
-    - Rock Tomb if you have an X-Atk left
-    - Otherwise Close Combat
+    - Close Combat
  ::::
 :::::
 
@@ -1594,7 +1605,7 @@ Fly out of the forest
     - Aura Sphere
  ::::
  ::::pokemon[Jynx]
-    - Rock Tomb 
+    - Rock Tomb  :info[Close Combat]{color=green}
  ::::
 :::::
 :::::trainer[Ace Trainer Theo]
@@ -1609,18 +1620,19 @@ Fly out of the forest
 :info[**Green x3**]{color=green}
 :::::trainer[Leader Wulfric]
 
-  For Cryogonal, need 3 Close Combats after this fight, 4 if going for X Attack Calem fight
+  If going for X Attack Calem fight, need 4 Close Combats after this fight.
 
- ::::pokemon[Abomasnow]
+  ::::pokemon[Abomasnow]
     - Aura Sphere
- ::::
- ::::pokemon[Cryogonal]
+  ::::
+  ::::pokemon[Cryogonal]
     - Close Combat
- ::::
- ::::pokemon[Avalugg]
+  ::::
+  ::::pokemon[Avalugg]
     - Aura Sphere
- ::::
+  ::::
 :::::
+
 :::::trainer[Ace Trainer Robbie]
  ::::pokemon[Carbink]{info="Moonblast does 40 (42)" infoColor=blue}
     - Swords Dance 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1790,7 +1790,8 @@ Buy Full Restores (>) if none left
     - Close Combat
  ::::
 :::::
-:info[Heal if 120 HP or lower]{color=yellow}
+:info[Heal to full if 120- HP (168- if doing safe Drasna)]{color=yellow}
+
 :::::trainer[Elite Four Drasna]
  ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
     - Swords Dance x2 
@@ -1808,6 +1809,25 @@ Buy Full Restores (>) if none left
     - Rock Tomb :info[Close Combat]{color=green}
  ::::
 :::::
+
+:::::trainer[Elite Four Drasna (safe)]
+ ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
+    - Swords Dance x3
+    - If at 24 HP or less
+      - Heal to full
+    - Shadow Claw
+ ::::
+ ::::pokemon[Noivern]
+    - Shadow Claw
+ ::::
+ ::::pokemon[Druddigon]
+    - Shadow Claw
+ ::::
+ ::::pokemon[Altaria]
+    - Shadow Claw
+ ::::
+:::::
+
 Heal to full
 
 Ether Close Combat

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -163,12 +163,13 @@ Deposit Squirtle
 :::::::trainer[Tierno]
   :::::pokemon[Corphish]
     :::if{source="Quacklin" condition="atk=(x/28+/x)"}
-    - Aerial Ace (Leer if did less than half)
-    - Aerial Ace (x2)
+      :::card{theme=error}
+         - 31.3% 2HKO range    (50% range if in Yellow HP)
+      :::
+      - Aerial Ace (Leer if did less than half)
+      - Aerial Ace (x2)
     :::
-    :::card{theme=error}
-      - 31.3% 2HKO range    (50% range if in Yellow HP)
-    :::
+    
     :::if{source="Quacklin" condition="atk=~(x/28+/x)"}
     - Leer
     - Swords Dance
@@ -374,7 +375,15 @@ Swap Farfetch’d back to front
     :::
   :::::
   :::::pokemon[Tyrunt]{info="if Unburden, you will outspeed after 2 Rock Tombs with Oran Berry" infoColor=blue}
-    :::if{source="Hawlucha" condition="atk=(21+/#/#) && startingLevel=19"}
+    :::if{source="Hawlucha" condition="atk=(x/26+/7-30) && startingLevel=19"}
+      - Karate Chop
+      - If Karate Chop crit
+         - Karate Chop
+      - Else
+         - Swords Dance
+         - Karate Chop
+    :::
+    :::if{source="Hawlucha" condition="atk=(21+/0-25/0-6) && startingLevel=19 || atk=(x/x/31) && startingLevel=19"}
       - Swords Dance x2
       - Karate Chop
     :::
@@ -387,10 +396,24 @@ Swap Farfetch’d back to front
       - Swords Dance
       - Karate Chop x2
     :::
-    :::if{source="Hawlucha" condition="atk=(x/x/21+) && startingLevel=20"}
+    :::if{source="Hawlucha" condition="atk=(x/x/26+) && startingLevel=20"}
       - Swords Dance x2
       - Rock Smash
      ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
+    :::
+    :::if{source="Hawlucha" condition="atk=(x/16+/25-) && startingLevel=20"}
+      ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
+      
+      - If you want to risk the damage range
+         - Swords Dance x2
+         - Rock Smash
+      - Else      
+         - Rock Smash
+         - If Rock Smash crits AND gets defense drop
+            - Rock Smash
+         - Else
+            - Swords Dance
+            - Rock Smash
     :::
     :::if{source="Hawlucha" condition="atk=~(x/x/21+) && startingLevel=20"}
       - Swords Dance

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -444,7 +444,7 @@ Use a Repel
   :::::
   :::::pokemon[Granbull]{info="Remeber HP After" infoColor=pink}
      - Wing Attack x2
-     - Tach FLing over Karate Chop
+     - Teach Fling over Karate Chop
     :::if{source="Hawlucha" condition="startingLevel=19"}
      ::damage[Granbull’s Headbutt does at 23]{source="Hawlucha" special=false offensive=false movePower=70 level=23 opponentLevel=24 stab=false opponentStat=66}
     :::
@@ -529,37 +529,18 @@ Use PP Up if only got one massage and it was bad
   :::::
   :::::pokemon[Braixen]
      - Wing Attack
-    :::if{source="Hawlucha" condition="startingLevel=19"}
-    ::damage[Wing Attack +6 Range]{source="Hawlucha" special=false offensive=true combatStages=6 healthThreshold=82 theme=error movePower=60 level=25 opponentLevel=30 stab=true  opponentStat=46 theme=error}
-    :::   
-    :::if{source="Hawlucha" condition="startingLevel=20"}
-    ::damage[Wing Attack +6 Range]{source="Hawlucha" special=false offensive=true combatStages=6 healthThreshold=82 theme=error movePower=60 level=26 opponentLevel=30 stab=true  opponentStat=46 theme=error}
-    :::   
   :::::
   :::::pokemon[Absol]
      - Wing Attack
-    :::if{source="Hawlucha" condition="startingLevel=19"}
-    ::damage[Wing Attack +6 Range]{source="Hawlucha" special=false offensive=true combatStages=6 healthThreshold=80 theme=error movePower=60 level=25 opponentLevel=28 stab=true  opponentStat=48 theme=error}
-    :::   
-    :::if{source="Hawlucha" condition="startingLevel=20"}
-    ::damage[Wing Attack +6 Range]{source="Hawlucha" special=false offensive=true combatStages=6 healthThreshold=80 theme=error movePower=60 level=26 opponentLevel=28 stab=true  opponentStat=48 theme=error}
-    :::   
   :::::
 :::::::
 Head to the gym
 :::::trainer[Roller Skater Kate]
  ::::pokemon[Meditite]
     - Wing Attack
-   ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=57 effectiveness=2 theme=error movePower=60 level=26 opponentLevel=28 stab=true  opponentStat=38 theme=error}
  ::::
  ::::pokemon[Mienfoo]
-    - Wing Attack
-    :::if{source="Hawlucha" condition="startingLevel=19"}
-    ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=66 effectiveness=2 theme=error movePower=60 level=26 opponentLevel=28 stab=true  opponentStat=31 theme=error}
-    :::   
-    :::if{source="Hawlucha" condition="startingLevel=20"}
-    ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=66 effectiveness=2 theme=error movePower=60 level=27 opponentLevel=28 stab=true  opponentStat=31 theme=error}
-    :::   
+    - Wing Attack 
  ::::
 :::::
 :::::trainer[Roller Skater Shun]
@@ -579,18 +560,16 @@ Head to the gym
 Fight Dash first if you already meet the requirements to OHKO Heracross or will not meet them at a higher level
 
 :info[One less IV if fighting Rolanda first at L28]{color=yellow}
-::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
-::damage[L28 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=28 opponentLevel=30 stab=true  opponentStat=52 theme=error}
-::damage[L29 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=29 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L28 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=28 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L29 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=29 opponentLevel=30 stab=true  opponentStat=52 theme=error}
 :::::::trainer[Roller Skater Dash]
   :::::pokemon[Heracross]
     :::if{source="Hawlucha" condition="startingLevel=19"}
      - (Swords Dance) Wing Attack
-     ::damage[Heracross’ Take Down does L27]{source="Hawlucha" special=false offensive=false movePower=90 level=27 opponentLevel=30 stab=false opponentStat=83}
     :::
     :::if{source="Hawlucha" condition="startingLevel=20"}
      - (Swords Dance) Wing Attack
-     ::damage[Heracross’ Take Down does L28]{source="Hawlucha" special=false offensive=false movePower=90 level=28 opponentLevel=30 stab=false opponentStat=83}
     :::
   :::::
 :::::::
@@ -833,7 +812,16 @@ Go right after the first climbing rope
   :::::
 :::::::
 ::::::::::
-:info[If Hawlucha fainted, do shopping early and PC heal Hawlucha]{color=yellow}
+
+:::card
+### Shopping (left):
+> #### Buy
+> - 11 Max Repels (^^) (12 if unconfident in movement)
+> - 1 Escape Rope (^^^)
+> - 11 Full Heals (^)
+> - 3 Revives (v<)
+> - MAX Hyper Potions (^^)
+:::
 
 Get **Lucky Egg**
 
@@ -848,15 +836,7 @@ Give Lucario Lucky Egg
 Swap Hawlucha with Lucario
 
 Fly to Coumarine
-:::card
-### Shopping (left):
-> #### Buy
-> - 11 Max Repels (^^) (12 if unconfident in movement)
-> - 1 Escape Rope (^^^)
-> - 11 Full Heals (^)
-> - 3 Revives (v<)
-> - MAX Hyper Potions (^^)
-:::
+
 No Wind: xx:10, xx:30, xx:50 for 10 minutes
 
 Pickup hidden **Power Plant Pass**

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -672,9 +672,9 @@ Head to the gym
 :info[Fight Rolanda before Dash if doing so will get you a better range on Heracross]{color="red"}
 
 :info[One less IV if fighting Rolanda first at L28]{color=yellow}
-::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
-::damage[L28 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=28 opponentLevel=30 stab=true  opponentStat=52 theme=error}
-::damage[L29 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=29 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L28 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=28 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L29 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=29 opponentLevel=30 stab=true  opponentStat=52 theme=error}
 :::::::trainer[Roller Skater Dash]
   :::::pokemon[Heracross]
     :::if{source="Hawlucha" condition="startingLevel=19"}

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -421,7 +421,6 @@ Swap Farfetch’d back to front
     :::if{source="Hawlucha" condition="atk=(x/x/26+) && startingLevel=20"}
       - Swords Dance x2
       - Rock Smash
-     ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
     :::
     :::if{source="Hawlucha" condition="atk=(x/16+/25-) && startingLevel=20"}
           

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -44,7 +44,7 @@
 :::
 _ported by Fortunate_
 
-_Updated by WaveWarrior_
+_Updated and maintained by WaveWarrior_
 
 _notes by wartab_ [base doc](https://docs.google.com/document/d/1eI4u7X_p3weBLY8hAMuaF-LwcAtmqeT3YdLiwZPC0r4/edit)
 
@@ -654,12 +654,8 @@ Head to the gym
  ::::
 :::::
 
-:::if{source="Hawlucha" condition="startingLevel=20 && atk=(x/x/15+)"}
-   :info[Don't teach Flying Press]{color="yellow"}
-:::
-:::if{source="Hawlucha" condition="startingLevel=20 && atk=(#/#/14-) || startingLevel=19"}
-   :info[Teach Flying Press over Fling  at Lv28]{color=yellow}
-:::
+
+:info[Teach Flying Press over Fling  at Lv28]{color=yellow}
 
 Fight Dash first if you already meet the requirements to OHKO Heracross or will not meet them at a higher level
 
@@ -692,22 +688,24 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
     :::
   :::::
   :::::pokemon[Hariyama]
-    :::if{source="Hawlucha" condition="atk=(x/25+/7+) && startingLevel=19"}
+    :::if{source="Hawlucha" condition="atk=(x/29+/11+) && startingLevel=19"}
      - Wing Attack
     :::
-    :::if{source="Hawlucha" condition="atk=~(x/25+/7+) && startingLevel=19"}
+    :::if{source="Hawlucha" condition="atk=~(x/29+/11+) && startingLevel=19"}
      - Flying Press
     :::
-    :::if{source="Hawlucha" condition="atk=(x/12+/#) && startingLevel=20"}
+    :::if{source="Hawlucha" condition="atk=(x/21+/4+) && startingLevel=20"}
      - Wing Attack
     :::
-    :::if{source="Hawlucha" condition="atk=~(x/12+/#) && startingLevel=20"}
+    :::if{source="Hawlucha" condition="atk=~(x/21+/4+) && startingLevel=20"}
      - Flying Press
      :::
   :::::
 :::::::
 
 Heal with Soda Pop unless very high HP
+
+You are faster than Korrina's Hawlucha with (x/x/22+)
 
 ::damage[Hawlucha Flying Press does]{source="Hawlucha" special=false offensive=false stab=true evs=10 movePower=80 level=29 opponentLevel=32 opponentStat=70}
 
@@ -799,11 +797,11 @@ Pickup **TM47 Low Sweep**
      - Shadow Claw
     :::
   :::::
-  :::::pokemon[Braixen]
+  :::::pokemon[Braixen]    
     :::if{source="Hawlucha" condition="speed=(12+/#/#) && startingLevel=19"}
      - Flying Press
     :::
-    :::if{source="Hawlucha" condition="speed=(3+/#/#) && startingLevel=20 && atk=~(x/28+/8+)"}
+    :::if{source="Hawlucha" condition="speed=(3+/#/#) && startingLevel=20 && atk=~(x/x/14+)"}
      - Flying Press
     :::
     :::if{source="Hawlucha" condition="speed=(3+/#/#) && startingLevel=20 && atk=(x/28+/8+)"}
@@ -843,12 +841,7 @@ Pickup **TM47 Low Sweep**
 Go right after the first climbing rope
 :::::trainer[Pokémon Ranger Chaise]
   ::::pokemon[Simisage]
-    :::if{source="Hawlucha" condition="startingLevel=20 && atk=(x/x/15+)"}
-      - Wing Attack x2
-    :::
-    :::if{source="Hawlucha" condition="startingLevel=20 && atk=(#/#/14-) || startingLevel=19"}
-      - Flying Press :info[100% at 73+ attack]{color="red"}
-    :::
+   - Flying Press :info[100% at 73+ attack]{color="red"}
 
   ::::
 :::::
@@ -911,10 +904,10 @@ Go right after the first climbing rope
         - Rock Tomb
     :::::     
     :::::pokemon[Gogoat]
-      :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
+      :::if{source="Hawlucha" condition="atk=(x/x/23+)"}
         - Wing Attack (Low Sweep if Lucario)
       :::
-      :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
+      :::if{source="Hawlucha" condition="atk=~(x/x/23+)"}
         - Flying Press (Low Sweep if Lucario)
       :::
     :::::
@@ -949,16 +942,6 @@ Go right after the first climbing rope
 
 If Hawlucha fainted, PC heal Hawlucha
 
-:::card
-### Shopping (left):
-> #### Buy
-> - 11 Max Repels (^^) (12 if unconfident in movement)
-> - 1 Escape Rope (^^^)
-> - 5 Full Heals (^)
-> - 2 Revive (v<)
-> - 16 Hyper Potions (^^)
-:::
-
 Get **Lucky Egg**
 
 :info[Heal Lucario if got hit by Acrobatics]{color=yellow}
@@ -972,6 +955,16 @@ Give Lucario Lucky Egg
 Swap Hawlucha with Lucario
 
 Fly to Coumarine
+
+:::card
+### Shopping (left):
+> #### Buy
+> - 11 Max Repels (^^)
+> - 1 Escape Rope (^^^)
+> - 5 Full Heals (^)
+> - 2 Revive (v<)
+> - 16 Hyper Potions (^^)
+:::
 
 No Wind: xx:10, xx:30, xx:50 for 10 minutes
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -913,8 +913,9 @@ Go right after the first climbing rope
     :::::pokemon[Jumpluff]
       - Swords Dance
       - Wing Attack
-      - _If Hawlucha dies _
+      - _If Hawlucha dies_
         - Switch to Lucario
+        - **[Mega Evolve]** Swords Dance
         - Rock Tomb
     :::::     
     :::::pokemon[Gogoat]
@@ -1128,7 +1129,7 @@ Pickup hidden **Power Plant Pass**
 :::::
 :info[Heal to full]{color=yellow}
 
-Use **Protein** on Lucario
+Use **Protein** on Lucario if you still have it
 
 Teach Shadow Claw over Bone Rush (Slot 4)
 
@@ -1882,7 +1883,7 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
     - Close Combat :info[Shadow Claw 15/16]{color="red"}
  ::::
  ::::pokemon[Altaria]
-    - Shadow Claw :info[Rock Tomb if used less than 8 Proteins on Lucario]{color="red"}
+    - Shadow Claw :info[Rock Tomb if used fewer than 8 Proteins on Lucario]{color="red"}
  ::::
 :::::
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -67,7 +67,7 @@ Pick Chespin
 
 :::::trainer[Pokémon Trainer Shauna]
  ::::pokemon[Froakie]
-    - Vine Whip x2 (/ x3)
+    - Vine Whip x2-3
  ::::
 :::::
 
@@ -82,8 +82,8 @@ Catch Bunnelby
 :::::
 :::::trainer[Lass Anna]
  ::::pokemon[Pikachu]
-    - Vine Whip x2/3
-    - Don't use the Paralyze Heal
+    - Vine Whip x2-3
+    - _Don't use the Paralyze Heal_
  ::::
 :::::
 Trade Bunnelby for Farfetch’d and move Farfetch’d to the front
@@ -117,7 +117,7 @@ Follow the drops in the gym
 
     :::if{source="Quacklin" condition="atk=(x/25+/x)"}
       :::card{theme="error"}
-        - Leer once if Harden (66.8% 2 shot)
+        - If Harden turn 1, Leer once then go back to Aerial Ace spam
       :::
     :::
 
@@ -138,7 +138,7 @@ Get **5 Luxury Balls**
   ::::pokemon[Squirtle]
     - If used Fury Cutter 
       - Fury Cutter x2
-      - Switch back to Aerial Ace if Withdraw or miss
+      - _Switch back to Aerial Ace if Withdraw or miss_
     - Otherwise: Aerial Ace x2 / x3
 
     :::if{source="Quacklin" condition="atk=(x/1-16/x)"}
@@ -242,7 +242,7 @@ At Trevor & Tierno fight:
   :::::pokemon[Corphish]
     - Swords Dance
     :::if{source="Quacklin" condition="atk=(x/20+/x)"} 
-      - If you didn't take any damage on Turn 1, Swords Dance again
+      - _If you didn't take any damage on Turn 1, Swords Dance again_
     :::
     - Aerial Ace until dead (Knock Off if Fletchling’s QA could kill Corphish)
   :::::
@@ -261,9 +261,9 @@ Pickup **PP Up** south of the previous fight
 
 :info[Take free heal if paralysed or low HP]{color=yellow}
 
-Pickup HP Up
+Pickup **HP Up**
 
-Head to the Pokémon Centre and leave immediately
+Head to the Pokémon Center and leave immediately
 
 Go to the lab and leave after the cutscene
 
@@ -334,7 +334,7 @@ Register Bike
 
 Buy a dozen Soda Pops from the Waitress
 
-Pickup hidden X Speed
+Pickup hidden **X-Speed**
 
 Go to Geosenge center and catch Hawlucha with Luxury Balls.
   - If Hawlucha and Farfetch’d are full HP, weaken with Aerial Ace.
@@ -372,7 +372,7 @@ Go to Geosenge center and catch Hawlucha with Luxury Balls.
   :::
 :::::
 
-Get massage (conservative estimate 90s for menu → massage, 30s for simple swap)
+Get massage
   - A little bit more friendly (74%, +5 friendship)
   - Somewhat more friendly (20%, +10 friendship)
   - Much more friendly (6%, +30 friendship)
@@ -388,7 +388,7 @@ Swap Farfetch’d back to front
 :::::::trainer[Leader Grant]
   :::::pokemon[Amaura]
     - Leer until Quackling dies
-    - Swap to Hawlucha
+    - Swap to Hawlucha (check nature if still have Oran Berry)
     - Karate Chop/Rock Smash
    :::if{source="Hawlucha" condition="startingLevel=19"}
      ::damage[Karate Chop without Leer ranges]{source="Hawlucha" special=false offensive=true healthThreshold=79 movePower=50 effectiveness=4 level=21 opponentLevel=25 stab=true opponentStat=35 theme=error}
@@ -448,11 +448,11 @@ Swap Farfetch’d back to front
 :::::::
 Swap Hawlucha to the front of party
 
-Pickup hidden Protein
+Pickup hidden **Protein**
 
 _Optionally pickup X-Defense for friendship gain_
 
-Pickup hidden Ether
+Pickup hidden **Ether**
 
 Get double massage if possible
 :::::trainer[Swimmer Marissa]
@@ -518,7 +518,7 @@ Use a Repel
     :::
   :::::
 :::::::
-:info[Heal to full]{color=yellow}
+:info[Heal to full if took damage]{color=yellow}
 :::::::trainer[Ace Trainer Monique]
   :::::pokemon[Doduo]
      - Swords Dance x2
@@ -575,11 +575,11 @@ Get Soothe Bell
 
 Equip **Soothe Bell**
 
-Use Iron
+Use **Iron**
 
-Use HP Up
+Use **HP Up**
 
-Use PP Up
+Use **PP Up**
 
 :info[Heal to full with Soda Pop]{color=yellow}
 :::::::trainer[Pokémon Trainer Calem]
@@ -629,7 +629,6 @@ Head to the gym
  ::::pokemon[Meditite]
     - Wing Attack
     ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=57 theme=error effectiveness=2 movePower=60 level=26 opponentLevel=28 stab=true opponentStat=38}
-  
  ::::
  ::::pokemon[Mienfoo]
     - Wing Attack 
@@ -663,7 +662,7 @@ Head to the gym
 
 :info[Teach Flying Press over Fling  at Lv28]{color=yellow}
 
-Fight Dash first if you already meet the requirements to OHKO Heracross or will not meet them at a higher level
+:info[Fight Rolanda before Dash if doing so will get you a better range on Heracross]{color="red"}
 
 :info[One less IV if fighting Rolanda first at L28]{color=yellow}
 ::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
@@ -682,7 +681,7 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
 :::::::trainer[Roller Skater Rolanda]
   :::::pokemon[Sawk]
     :::if{source="Hawlucha" condition="startingLevel=19 && speed=(0+/11-/x) || startingLevel=20 && speed=(30-/2-/x)"}
-      - Slower than Sawk after one Low Sweep
+      - _Slower than Sawk after one Low Sweep_
     :::
      - Swords Dance
      - Wing Attack
@@ -709,9 +708,9 @@ Fight Dash first if you already meet the requirements to OHKO Heracross or will 
   :::::
 :::::::
 
-Heal with Soda Pop unless very high HP (you can heal turn 1 if don't need to X Attack)
+:info[Heal with Soda Pop unless very high HP (you can heal turn 1 if don't need to X Attack)]
 
-You are faster than Korrina's Hawlucha with (x/x/22+)
+:info[You are faster than Korrina's Hawlucha with (x/x/22+)]{color="red"}
 
 ::damage[Hawlucha Flying Press does]{source="Hawlucha" special=false offensive=false stab=true evs=10 movePower=80 level=29 opponentLevel=32 opponentStat=70}
 
@@ -850,7 +849,6 @@ Go right after the first climbing rope
 :::::trainer[Pokémon Ranger Chaise]
   ::::pokemon[Simisage]
    - Flying Press :info[100% at 73+ attack]{color="red"}
-
   ::::
 :::::
 :::::trainer[Pokémon Ranger Brooke]
@@ -961,7 +959,7 @@ Go right after the first climbing rope
 > - MAX Hyper Potions (^^) (Should be 19 with standard shopping)
 :::
 
-Use any remaining Sweet Hearts on Hawlucha (3 friendship per Sweet Heart)
+Use any remaining Sweet Hearts on Hawlucha
 
 Get **Lucky Egg**
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -46,7 +46,7 @@ _ported by Fortunate_
 
 _notes by wartab_ [base doc](https://docs.google.com/document/d/1eI4u7X_p3weBLY8hAMuaF-LwcAtmqeT3YdLiwZPC0r4/edit)
 :::card
-Set console date to 14th February and time to 23:04 (adapt for skill level)
+Set console date to 14th February and time to 23:03 (adapt for skill level)
 :::
 - Choose the girl and give a single character name (! is fastest)
 - Open options and set 
@@ -86,26 +86,27 @@ Trade Bunnelby for Farfetch’d and move Farfetch’d to the front
  ::::
 :::::
 Follow the drops in the gym
-:::::trainer[Lass Charlotte]
- ::::pokemon[Kakuna]
+::::trainer[Lass Charlotte]
+ :::pokemon[Kakuna]
     -  Aerial Ace
- ::::
- ::::pokemon[Combee]
+ :::
+ :::pokemon[Combee]
     -  Aerial Ace
- ::::
- :::::trainer[Leader Viola]
- ::::pokemon[Surskit]
+  :::
+::::
+::::trainer[Leader Viola]
+  :::pokemon[Surskit]
     - Aerial Ace
- ::::
- ::::pokemon[Vivillon]
+  :::
+  :::pokemon[Vivillon]
     - Aerial Ace spam
-   :::card{theme=error}
+    :::card{theme=error}
       - 21- Atk (24- IV) 93.8% 2 shot
       - 22+ Atk (25+ IV) Leer once if Harden (66.8% 2 shot)
-   :::
+    :::
     - Teach Knock Off over Fury Attack (Slot 3)
- ::::
-:::::
+  :::
+::::
 Get the **3 X-Attacks** and **3 X-Defenses** in trainer school.
 
 Grab the **Repel**
@@ -116,30 +117,41 @@ Get **5 Luxury Balls**
     -  Aerial Ace (+ Fury Cutter)
    ::damage[Aerial Ace Ranges]{source="Quacklin" special=false offensive=true movePower=60 level=13 healthThreshold=31 opponentLevel=10 stab=true opponentStat=17 theme=error effectiveness=2 stab=true}
  ::::
- ::::pokemon[Squirtle]
+
+  ::::pokemon[Squirtle]
     - If used Fury Cutter 
       - Fury Cutter x2
     - Otherwise: Aerial Ace x2 / x3
-  :::card{theme=error}
-    - 2HKO Ranges
-        - 7.4% at 22/23 1-16
-       -  80.9% at 24+ 17+
-  :::
-   ::damage[Water Gun]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17}
-   ::damage[Water Gun (Torrent)]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17 torrent=true}
- ::::
- ::::pokemon[Charmander]
-  :::if{source="Quacklin" condition="atk=(x/17+/x)"}
-    :info[Very likely to knock Charmander into Blaze]{color=red}
-  :::
-  :::if{source="Quacklin" condition="atk=(x/24+/x)"}
-    :info[Leer + Aerial Ace is 14 / 16]{color=red}
-  :::
+
+    :::if{source="Quacklin" condition="atk=(x/1-16/x)"}
+      :::card{theme=error}
+        - Aerial Ace 2HKO Range: 7.4%
+      :::
+    :::
+  
+    :::if{source="Quacklin" condition="atk=(x/17+/x)"}
+      :::card{theme=error}
+        - Aerial Ace 2HKO Range: 80.9%
+      :::
+    :::
+
+    ::damage[Water Gun]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17}
+    ::damage[Water Gun (Torrent)]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17 torrent=true}
+  ::::
+
+
+  ::::pokemon[Charmander]
+    :::if{source="Quacklin" condition="atk=(x/17+/x)"}
+      :info[Very likely to knock Charmander into Blaze]{color=red}
+    :::
+    :::if{source="Quacklin" condition="atk=(x/24+/x)"}
+      :info[Leer + Aerial Ace is 14 / 16]{color=red}
+    :::
 
     - Aerial Ace x2
-   ::damage[Ember]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17}
-   ::damage[Ember (Blaze)]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17 torrent=true}
- ::::
+    ::damage[Ember]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17}
+    ::damage[Ember (Blaze)]{source="Quacklin" offensive=false special=true movePower=40 level=13 opponentLevel=10 stab=true opponentStat=17 torrent=true}
+  ::::
 :::::
 :info[**Free heal**]{color=pink}
 
@@ -404,16 +416,13 @@ Swap Farfetch’d back to front
     :::if{source="Hawlucha" condition="atk=(x/16+/25-) && startingLevel=20"}
       ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
       
-      - If you want to risk the damage range
-         - Swords Dance x2
-         - Rock Smash
-      - Else      
-         - Rock Smash
-         - If Rock Smash crits AND gets defense drop
-            - Rock Smash
-         - Else
-            - Swords Dance
-            - Rock Smash
+    
+      - Rock Smash
+      - If Rock Smash crits AND gets defense drop
+        - Rock Smash
+      - Else
+        - Swords Dance
+        - Rock Smash
     :::
     :::if{source="Hawlucha" condition="atk=~(x/x/21+) && startingLevel=20"}
       - Swords Dance

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -136,10 +136,11 @@ Get **5 Luxury Balls**
  ::::
 
   ::::pokemon[Squirtle]
-    - If used Fury Cutter 
+    - _If used Fury Cutter _
       - Fury Cutter x2
       - _Switch back to Aerial Ace if Withdraw or miss_
-    - Otherwise: Aerial Ace x2 / x3
+    - _Otherwise_
+      Aerial Ace x2 / x3
 
     :::if{source="Quacklin" condition="atk=(x/1-16/x)"}
       :::card{theme=error}
@@ -281,6 +282,8 @@ Pickup **TM65 Shadow Claw** at the branch after the path goes down
    ::damage[Aerial Ace +2 ranges]{source="Quacklin" special=false combatStages=2 offensive=true movePower=60 level=16 healthThreshold=42 combat opponentLevel=18 stab=true opponentStat=17 theme=error} 
  ::::
 :::::
+
+:info[Don't heal poison]{color="red}
 
 :info[Heal if necessary]{color="yellow"}
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -462,7 +462,7 @@ Get double massage if possible
 :::::trainer[Swimmer Marissa]
  ::::pokemon[Masquerain]
     - _Optionally use X-Defense_
-    - Swords Dance / Encore on Gust and die
+    - Swords Dance until you die (can Encore on Gust)
  ::::
 :::::
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1246,7 +1246,11 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Teach Close Combat over Shadow Claw (Slot 4)
  ::::
 :::::
+
+:info[Use PP Up(s) on Close Combat whenever you heal next]{color=red}
+
 :info[Heal to full if 66 (68) HP or less]{color=yellow}
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Houndoom]
     - Aura Sphere
@@ -1345,9 +1349,8 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
     - Give up on Dragon Pulse
  ::::
 :::::
-- Bag
-  - Heal to full
-  - Use PP Up on Close Combat (both if have them)
+- Heal to full
+- Use PP Up(s) on Close Combat if haven't yet
 :::::trainer[Team Flare Double 3]
  ::::pokemon[Scrafty]
     - Aura Sphere
@@ -1438,7 +1441,7 @@ Max Repel
     - Rock Tomb
  ::::
  ::::pokemon[Crawdaunt]
-    - If can tank 100 / (102)
+    - If can tank 100 / (102) and desperate for time save
       - Swords Dance
     - Aura Sphere
  ::::
@@ -1451,7 +1454,18 @@ Max Repel
 :::::
 
 Free Heal
-
+:::::trainer[Pokémon Trainer Trevor (slower if Static, faster if no Static)]
+ ::::pokemon[Raichu]
+    - Close Combat
+ ::::
+ ::::pokemon[Florges]
+    - **If no Static**: Swords Dance + Close Combat
+    - **If Static** Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
+ ::::
+ ::::pokemon[Aerodactyl]
+    - Rock Tomb :info[Close Combat if did safe Trevor]{color=gray}
+ ::::
+:::::
 :::::trainer[Pokémon Trainer Trevor (safe)]
  ::::pokemon[Raichu]
     - Swords Dance (+ heal paralysis)
@@ -1465,20 +1479,7 @@ Free Heal
     - Otherwise Close Combat
  ::::
 :::::
-:::::trainer[Pokémon Trainer Trevor (slower if Static, faster if no Static)]
- ::::pokemon[Raichu]
-    - Close Combat
- ::::
- ::::pokemon[Florges]
-    - **If no Static**: Swords Dance + Close Combat
-    - **If Static** Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
- ::::
- ::::pokemon[Aerodactyl]
-    - Rock Tomb if you have an X-Atk left
-    - Close Combat
-    - (Rock Tomb Jynx/Wulfric's Cryogonal to save a Close Combat)
- ::::
-:::::
+
 Bike to the forest
 
 :info[Heal if 71 or less HP]{color=yellow}
@@ -1513,7 +1514,7 @@ Fly out of the forest
     - Aura Sphere
  ::::
  ::::pokemon[Jynx]
-    - Rock Tomb :info[Close Combat if did safe Trevor]{color=gray}
+    - Rock Tomb 
  ::::
 :::::
 :::::trainer[Ace Trainer Theo]
@@ -1534,8 +1535,7 @@ Fly out of the forest
     - Aura Sphere
  ::::
  ::::pokemon[Cryogonal]
-    - **If did risky Trevor**: Rock Tomb
-    - **Otherwise** Close Combat
+    - Close Combat
  ::::
  ::::pokemon[Avalugg]
     - Aura Sphere
@@ -1589,7 +1589,8 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
 :::::
 
 :info[**Free heal from Ranger**]{color=pink}
-**If you forgot to heal: https://pastebin.com/bS3XdUv8 **
+
+:info[**If you forgot to heal: https://pastebin.com/bS3XdUv8**]
 
 
 :::::trainer[Veteran Gerard]
@@ -1707,14 +1708,13 @@ Buy Full Restores (>) if none left
     - Shadow Claw
  ::::
  ::::pokemon[Noivern]
-    - Close Combat (Rock Tomb if Close Combat on Probopass)
-    - :info[Close Combat if safety PP Up]{color=gray}
+    - Close Combat 
  ::::
  ::::pokemon[Druddigon]
-    - Close Combat (+4 Shadow Claw 14/16)
+    - Close Combat
  ::::
  ::::pokemon[Altaria]
-    - Close Combat (+4 Shadow Claw 15/16)
+    - Rock Tomb :info[Close Combat]{color=gray}
  ::::
 :::::
 Heal to full

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -99,6 +99,10 @@ Follow the drops in the gym
  ::::
  ::::pokemon[Vivillon]
     - Aerial Ace spam
+   :::card{theme=error}
+      - 21- Atk (24- IV) 93.8% 2 shot
+      - 22+ Atk (25+ IV) Leer once if Harden (66.8% 2 shot)
+   :::
     - Teach Knock Off over Fury Attack (Slot 3)
  ::::
 :::::
@@ -272,15 +276,24 @@ Pickup **TM65 Shadow Claw** at the branch after the path goes down
   :::::  
 :::::::
 ::damage[Heal to full if you are poisoned or can die to Brick Break]{source="Quacklin" special=false offensive=false movePower=75 level=17 opponentLevel=20 stab=true opponentStat=31}
+
 :::::trainer[Team Flare Double]
+  :::if{source="Quacklin" condition="atk=(x/6-17/x)"}
+    :info[Don't Swords Dance (Scraggy 90.2% 2HKO, 41.8% SD+AA)]{color=red}
+    ::::pokemon[Scraggy]
+      - Aerial Ace x2
+    ::::
+  :::
+  :::if{source="Quacklin" condition="atk=(x/5-/x) || atk=(x/18+/x)"}
    - Swords Dance Turn 1     
- ::::pokemon[Scraggy]
+    ::::pokemon[Scraggy]
+      - Aerial Ace
+    ::damage[Aerial Ace Range]{source="Quacklin" special=false offensive=true combatStages=2 effectiveness=2 movePower=60 level=17 healthThreshold=50 opponentLevel=20 stab=true opponentStat=33 theme=error}
+    ::::
+  :::
+  ::::pokemon[Croagunk]
     - Aerial Ace
-   ::damage[Aerial Ace Range]{source="Quacklin" special=false offensive=true combatStages=2 effectiveness=2 movePower=60 level=17 healthThreshold=50 opponentLevel=20 stab=true opponentStat=33 theme=error}
- ::::
- ::::pokemon[Croagunk]
-    - Aerial Ace
- ::::
+  ::::
 :::::
 
 Die to a wild encounter.
@@ -334,12 +347,20 @@ Go to Geosenge centre and catch Hawlucha with Luxury Balls.
 ####    - Reset for another Hawlucha
   :::
 :::::
+
 Get massage (conservative estimate 90s for menu → massage, 30s for simple swap)
   - A little bit more friendly (74%, +5 friendship)
   - Somewhat more friendly (20%, +10 friendship)
   - Much more friendly (6%, +30 friendship)
 
+
+
 Swap Farfetch’d back to front
+:::if{source="Hawlucha" condition="atk=(x/26+/7+) && startingLevel=19"}
+  :info[_Optional: Don't swap Farfetch'd back to front, Karate Chop is 13/16 to kill Amaura (guaranteed at x/x/26+)_]{color=red}
+:::
+
+
 :::::::trainer[Leader Grant]
   :::::pokemon[Amaura]
     - Leer until Quackling dies
@@ -356,7 +377,6 @@ Swap Farfetch’d back to front
     :::if{source="Hawlucha" condition="atk=(21+/#/#) && startingLevel=19"}
       - Swords Dance x2
       - Karate Chop
-     ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=21 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
     :::
     :::if{source="Hawlucha" condition="atk=(16-20/x/x) && startingLevel=19"}
       - Karate Chop
@@ -382,8 +402,7 @@ Swap Hawlucha to the front of party
 
 Pickup hidden Protein
 
-_Optionally_
-  - _pickup X-Defense_
+_Optionally pickup X-Defense_
 
 Pickup hidden Ether
 
@@ -439,8 +458,14 @@ Use a Repel
      - Swords Dance x2
      - Wing Attack
   :::::
-  :::::pokemon[Doduo]{info="Has Quick Attack"}
+  :::::pokemon[Helioptile]{info="Has Quick Attack"}
      - Karate Chop / Fling
+     :::if{source="Hawlucha" condition="startingLevel=19"}
+      ::damage[Heliptile QA does at 23]{source="Hawlucha" special=false offensive=false movePower=40 level=23 opponentLevel=25 stab=true opponentStat=25}
+     :::
+     :::if{source="Hawlucha" condition="startingLevel=20"}
+      ::damage[Heliptile QA does at 23]{source="Hawlucha" special=false offensive=false movePower=40 level=24 opponentLevel=25 stab=true opponentStat=25}
+     :::
   :::::
   :::::pokemon[Granbull]{info="Remeber HP After" infoColor=pink}
      - Wing Attack x2
@@ -519,7 +544,7 @@ Use PP Up if only got one massage and it was bad
      - Wing Attack x2
     :::
     :::if{source="Hawlucha" condition="speed=(x/24+/#) && startingLevel=20"}
-     - Swords Dance
+     - Swords Dance (or X-Speed anyway for friendship gain, Fake Out is most likely outcome)
      - Encore (if no Fake Out/Light Screen, the run is over, heal until Light Screen?)
      - Swords Dance x2
      - Encore
@@ -761,12 +786,12 @@ Go right after the first climbing rope
    - Teach Rock Tomb over Shadow Claw (slot 3)
 :::
 :::if{source="Hawlucha" condition="startingLevel=19"}
-::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=32 opponentLevel=30 stab=true effectiveness=2 opponentStat=44}
+::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=32 evs=10 opponentLevel=30 stab=true effectiveness=2 opponentStat=44}
 ::::
 :::if{source="Hawlucha" condition="startingLevel=20"}
-::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=33 opponentLevel=30 stab=true effectiveness=2 opponentStat=44}
+::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=33 evs=10 opponentLevel=30 stab=true effectiveness=2 opponentStat=44}
 :::
-::damage[Take down does]{source="Hawlucha" special=false offensive=false movePower=90 level=33 opponentLevel=34 stab=false opponentStat=88}
+::damage[Take down does]{source="Hawlucha" special=false offensive=false movePower=90 level=33 opponentLevel=34 evs=10 stab=false opponentStat=88}
 
 ::::::::::if{source="Hawlucha" condition="speed=~(10-/x/x) && startingLevel=20 || speed=~(18-/x/x) && startingLevel=19"}
 :::::::trainer[Leader Ramos (without Lucario)]
@@ -812,6 +837,8 @@ Go right after the first climbing rope
   :::::
 :::::::
 ::::::::::
+
+If Hawlucha fainted, PC heal Hawlucha
 
 :::card
 ### Shopping (left):
@@ -1088,7 +1115,7 @@ Pickup **Rare Candy**
 
 :::::trainer[Psychic Paschal]{info="Remember HP after" infoColor=pink}
  ::::pokemon[Exeggutor]
-    - Shadow Claw x2
+    - Shadow Claw x2 (Swords Dance + Shadow Claw 94.5% OHKO, slightly faster)
  ::::
 :::::
 
@@ -1174,7 +1201,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
  ::::
 :::::
 :::::trainer[Team Flare Grunt]
- ::::pokemon[Swalot]{info="+2 Spit Up does 32/(33) infoColor=blue"}
+ ::::pokemon[Swalot]{info="+2 Spit Up does 32/(33)" infoColor=blue}
     - Swords Dance x2 (x3 if Swalot is still Stockpiled)
     - Shadow Claw
  ::::
@@ -1399,7 +1426,10 @@ Max Repel
     - Give up on Extreme Speed
  ::::
 :::::
-:::::trainer[Pokémon Trainer Trevor]
+
+Free Heal
+
+:::::trainer[Pokémon Trainer Trevor (safe)]
  ::::pokemon[Raichu]
     - Swords Dance (+ heal paralysis)
     - Rock Tomb
@@ -1409,8 +1439,21 @@ Max Repel
  ::::
  ::::pokemon[Aerodactyl]
     - Rock Tomb if you have an X-Atk left
-    - Otherwise
-      - Close Combat
+    - Otherwise Close Combat
+ ::::
+:::::
+:::::trainer[Pokémon Trainer Trevor (slower if Static, faster if no Static)]
+ ::::pokemon[Raichu]
+    - Close Combat
+ ::::
+ ::::pokemon[Florges]
+    - **If no Static**: Swords Dance + Close Combat
+    - **If Static** Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
+ ::::
+ ::::pokemon[Aerodactyl]
+    - Rock Tomb if you have an X-Atk left
+    - Close Combat
+    - (Rock Tomb Jynx/Wulfric's Cryogonal to save a Close Combat)
  ::::
 :::::
 Bike to the forest
@@ -1447,7 +1490,7 @@ Fly out of the forest
     - Aura Sphere
  ::::
  ::::pokemon[Jynx]
-    - Rock Tomb :info[Close Combat]{color=gray}
+    - Rock Tomb :info[Close Combat if did safe Trevor]{color=gray}
  ::::
 :::::
 :::::trainer[Ace Trainer Theo]
@@ -1461,11 +1504,15 @@ Fly out of the forest
 :info[**Yellow x1**]{color=yellow}
 :info[**Green x3**]{color=green}
 :::::trainer[Leader Wulfric]
+
+  For Cryogonal, need 3 Close Combats after this fight, 4 if going for X Attack Calem fight
+
  ::::pokemon[Abomasnow]
     - Aura Sphere
  ::::
  ::::pokemon[Cryogonal]
-    - Close Combat
+    - **If did risky Trevor**: Rock Tomb
+    - **Otherwise** Close Combat
  ::::
  ::::pokemon[Avalugg]
     - Aura Sphere
@@ -1489,7 +1536,7 @@ Fly out of the forest
  ::::
 :::::
 
-:info[Heal to full]{color=yellow}
+:info[Heal if 85- HP]{color=yellow}
 
 Teach Shadow Claw over Aura Sphere (Slot 1)
 
@@ -1498,7 +1545,7 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
     - If you have an X-Attack left (and 2 Close Combats)
       - X Attack
     - Otherwise
-      - Swords Dance (x2 if Faked Out)
+      - Swords Dance (again if get Fake Out)
     - Shadow Claw
  ::::
  ::::pokemon[Delphox]
@@ -1517,14 +1564,18 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
     - Close Combat
  ::::
 :::::
+
 :info[**Free heal from Ranger**]{color=pink}
+**If you forgot to heal: https://pastebin.com/bS3XdUv8 **
+
+
 :::::trainer[Veteran Gerard]
  ::::pokemon[Banette]
     - Shadow Claw
  ::::
  ::::pokemon[Leafeon]
     - Swords Dance 
-    -Close Combat
+    - Close Combat
  ::::
 ::::: 
 :::::trainer[Veteran Timeo]
@@ -1547,7 +1598,7 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
 :::::
 :::::trainer[Veteran Catrina]
  ::::pokemon[Glaceon]
-    - If Gigalith used Protect on Close Combat and you don't have 7 Close Combats
+    - If Gigalith used Protect on Close Combat and you didn't get safety PP UP
       - Swords Dance
       - Rock Tomb
     - Otherwise
@@ -1595,7 +1646,7 @@ Buy Full Restores (>) if none left
     - Close Combat
  ::::
  ::::pokemon[Chandelure]
-    - If low HP or playing it safe
+    - If took more damage than Talonflame QA
       - Shadow Claw
     - Otherwise
       - Rock Tomb
@@ -1610,9 +1661,8 @@ Buy Full Restores (>) if none left
     - Shadow Claw
  ::::
  ::::pokemon[Probopass]{info="Earth Power does 76-88 (90)" infoColor=blue}
-    - No Torment
-      - Shadow Claw x2
-    - Otherwise 
+    - **No Torment:** Shadow Claw x2
+    - **Otherwise**
       - Rock Tomb (Shadow Claw if you miss) 
       - Close Combat
  ::::
@@ -1625,7 +1675,7 @@ Buy Full Restores (>) if none left
     - Close Combat
  ::::
 :::::
-:info[Heal if 104 HP or lower]{color=yellow}
+:info[Heal if 120 HP or lower]{color=yellow}
 :::::trainer[Elite Four Drasna]
  ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
     - Swords Dance x2 
@@ -1635,24 +1685,24 @@ Buy Full Restores (>) if none left
  ::::
  ::::pokemon[Noivern]
     - Close Combat (Rock Tomb if Close Combat on Probopass)
-    - :info[Clost Combat if safety PP Up]{color=gray}
+    - :info[Close Combat if safety PP Up]{color=gray}
  ::::
  ::::pokemon[Druddigon]
-    - Close Combat
+    - Close Combat (+4 Shadow Claw 14/16)
  ::::
  ::::pokemon[Altaria]
-    - Close Combat
+    - Close Combat (+4 Shadow Claw 15/16)
  ::::
 :::::
 Heal to full
 
 Ether Close Combat
 
-Equip Lucarionite
+**Equip Lucarionite**
 
 :::::trainer[Elite Four Siebold]
  ::::pokemon[Clawitzer]
-    - [Mega Evolve] Close Combat
+    - **[Mega Evolve]** Close Combat
  ::::
  ::::pokemon[Gyarados]{info="15/16 range" infoColor=red}
     - Swords Dance
@@ -1679,7 +1729,7 @@ Equip Lucarionite
     - Close Combat
  ::::
  ::::pokemon[Aurorus]
-    - Rock Tomb :info[CloseCombat if you took no damage]{color=gray}
+    - Rock Tomb :info[Close Combat if you took no damage]{color=gray}
     - If miss, you are at full HP and Aurorus used Reflect
       - Swords Dance
       - If you got hit by Thunder

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -43,6 +43,7 @@
 :::tracker{species="Lucario" nature="hasty" generation=6 hpIV=6 attackIV=25 defenseIV=16 spAttackIV=25 spDefenseIV=19 speedIV=31 baseStats="[[70, 110, 70, 115, 70, 90]]"}
 :::
 _ported by Fortunate_
+_Updated by WaveWarrior_
 
 _notes by wartab_ [base doc](https://docs.google.com/document/d/1eI4u7X_p3weBLY8hAMuaF-LwcAtmqeT3YdLiwZPC0r4/edit)
 :::card

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -853,9 +853,16 @@ Go right after the first climbing rope
 :::::trainer[Pokémon Ranger Brooke]
  ::::pokemon[Roselia]
     - Wing Attack
+    :::if{source="Hawlucha" condition="startingLevel=20"}
+      - _Give up on Bounce_
+    :::
  ::::
  ::::pokemon[Wormadam]
     - Wing Attack
+    :::if{source="Hawlucha" condition="startingLevel=19"}
+      - _Give up on Bounce_
+    :::
+    - _Give up on Quick Guard_
  ::::
 :::::
 :::::trainer[Pokémon Ranger Twiggy]
@@ -1572,7 +1579,7 @@ Max Repel
     - If didn’t Swords Dance yet
       - Swords Dance
     - Close Combat
-    - Give up on Extreme Speed
+    - _Give up on Extreme Speed_
  ::::
 :::::
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -53,8 +53,11 @@ _8 Protein and 1 Protein Strat_ [base doc](https://pastebin.com/rahQFiqH)
 :::card
 Set console date to 14th February and time to 23:03 (adapt for skill level)
 :::
-- Choose the girl and give a single character name (! is fastest)
-- Open options and set 
+ 
+
+Choose the girl and give a single character name (! is fastest)
+
+Open options and set 
   - Text Speed Fast
   - Battle Effects: Off
   - Battle Style Set
@@ -174,9 +177,7 @@ Deposit Squirtle
 > #### Buy 
 > - Swords Dance (vv)
 
-At the grass after Lucario cutscene:
-  - Repel
-  - Teach Swords Dance over Fury Cutter (slot 2).
+At the grass after Lucario cutscene, Repel and teach Swords Dance over Fury Cutter (slot 2)
 
 :::::::trainer[Tierno]
   :::::pokemon[Corphish]
@@ -228,23 +229,23 @@ At Trevor & Tierno fight:
   - Equip Berry Juice
 
 ::::::trainer[Trevor & Tierno]{info="Remember HP after" infoColor=pink}
-   - Swords Dance
-   :::if{source="Quacklin" condition="atk=(x/20+/x)"} 
-  - If you didn't take any damage on Turn 1, Swords Dance again
-   :::
- :::::pokemon[Corphish]
-   - Aerial Ace until dead (Knock Off if Fletchling’s QA could kill Corphish)
- :::::
- :::::pokemon[Pikachu]
-   - Knock Off
+  :::::pokemon[Corphish]
+    - Swords Dance
+    :::if{source="Quacklin" condition="atk=(x/20+/x)"} 
+      - If you didn't take any damage on Turn 1, Swords Dance again
+    :::
+    - Aerial Ace until dead (Knock Off if Fletchling’s QA could kill Corphish)
+  :::::
+  :::::pokemon[Pikachu]
+    - Knock Off
     ::damage[Thunder Shock L14]{source="Quacklin" special=true offensive=false movePower=40 level=14 opponentLevel=14 stab=true effectiveness=2 opponentStat=19}
     ::damage[Thunder Shock L15]{source="Quacklin" special=true offensive=false movePower=40 level=15 opponentLevel=14 stab=true effectiveness=2 opponentStat=19}
- :::::
- :::::pokemon[Flabébé]
-   - Aerial Ace
+  :::::
+  :::::pokemon[Flabébé]
+    - Aerial Ace
     ::damage[Fairy Wind L14]{source="Quacklin" special=true offensive=false movePower=40 level=14 opponentLevel=14 stab=true opponentStat=22}
     ::damage[Fairy Wind L15]{source="Quacklin" special=true offensive=false movePower=40 level=15 opponentLevel=14 stab=true opponentStat=22}  
- :::::
+  :::::
 ::::::
 Pickup **PP Up** south of the previous fight
 
@@ -303,11 +304,11 @@ Pickup **TM65 Shadow Claw** at the branch after the path goes down
       - Aerial Ace x2
     ::::
   :::
-  :::if{source="Quacklin" condition="atk=(x/5-/x) || atk=(x/18+/x)"}
-   - Swords Dance Turn 1     
+  :::if{source="Quacklin" condition="atk=(x/5-/x) || atk=(x/18+/x)"}    
     ::::pokemon[Scraggy]
+      - Swords Dance
       - Aerial Ace
-    ::damage[Aerial Ace Range]{source="Quacklin" special=false offensive=true combatStages=2 effectiveness=2 movePower=60 level=17 healthThreshold=50 opponentLevel=20 stab=true opponentStat=33 theme=error}
+      ::damage[Aerial Ace Range]{source="Quacklin" special=false offensive=true combatStages=2 effectiveness=2 movePower=60 level=17 healthThreshold=50 opponentLevel=20 stab=true opponentStat=33 theme=error}
     ::::
   :::
   ::::pokemon[Croagunk]

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1124,7 +1124,7 @@ Pickup **Rare Candy**
       - Shadow Claw
       - Finish setting up Swords Dance
       - Aura Sphere
-      - _If Shadow Claw crit kills Mawile, stop setting up Swords Dance and 2HKO Sylveon (Dazzling Gleam does ~50%)_
+      - _If Shadow Claw crit kills Mawile, stop setting up Swords Dance and 2HKO Sylveon (Dazzling Gleam does 54-63 (64))_
     - If Iron Defense Turn 3
       - Rock Tomb (crit is 9/16 range)
       - Aura Sphere (6/16 range from full)
@@ -1439,7 +1439,7 @@ PC Heal Lucario and Lapras:
  ::::pokemon[Gyarados]
     - Switch to Lapras
     - Rock Smash
-    - If not full HP and no Outrage
+    - If Lucario not full HP and no Outrage
       - Swap in Squirtle
       - Heal Lucario to full (Squirtle dies)
       - Switch in Lucario

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -963,7 +963,7 @@ Go right after the first climbing rope
 > - MAX Hyper Potions (^^) (Should be 19 with standard shopping)
 :::
 
-Use any remaining Sweet Hearts on Hawlucha
+Use any remaining Sweet Hearts on Hawlucha (also Protein if died to Ramos)
 
 Get **Lucky Egg**
 
@@ -1112,7 +1112,7 @@ Pickup hidden **Power Plant Pass**
 :::::trainer[Leader Clemont]
  ::::pokemon[Emolga]
     - Swords Dance
-    - _Emolga uses Volt Switch and switches out_
+    - _Emolga uses Volt Switch and switches out. If you get the ultra rare Quick Attack, use Rock Tomb._
  ::::
  ::::pokemon[Magneton]
     - Bone Rush 
@@ -1911,9 +1911,9 @@ Ether Close Combat
  ::::pokemon[Clawitzer]
     - **[Mega Evolve]** Close Combat
  ::::
- ::::pokemon[Gyarados]
+ ::::pokemon[Gyarados]{info="15/16 with 6 Proteins" infoColor=red}
     - Swords Dance
-    - Close Combat   
+    - Close Combat
  ::::
  ::::pokemon[Barbaracle]
     - Close Combat

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1121,9 +1121,15 @@ Pickup **Rare Candy**
   ::::pokemon[Mawile]
     - Swords Dance x3
     - If Iron Defense on Turn 1 or 2
-      - Shadow Claw, then finish setting up Swords Dance
+      - Shadow Claw
+      - Finish setting up Swords Dance
+      - Aura Sphere
       - _If Shadow Claw crit kills Mawile, stop setting up Swords Dance and 2HKO Sylveon (Dazzling Gleam does ~50%)_
-    - Aura Sphere (Shadow Claw if no Iron Defenses)
+    - If Iron Defense Turn 3
+      - Rock Tomb (crit is 9/16 range)
+      - Aura Sphere (6/16 range from full)
+    - If no Iron Defense
+      - Shadow Claw
   ::::
   ::::pokemon[Mr. Mime]
     - Shadow Claw
@@ -1433,9 +1439,12 @@ PC Heal Lucario and Lapras:
  ::::pokemon[Gyarados]
     - Switch to Lapras
     - Rock Smash
-      - If not full HP and no Outrage switch to Squirtle 
-      - Revive Lapras 
-    - Switch to Lucario
+    - If not full HP and no Outrage
+      - Swap in Squirtle
+      - Heal Lucario to full (Squirtle dies)
+      - Switch in Lucario
+    - Otherwise
+      - Switch in Lucario
     - Swords Dance
     - Rock Tomb
  ::::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -110,7 +110,7 @@ Get **5 Luxury Balls**
 :::::trainer[Pokémon Professor Sycamore]
  ::::pokemon[Bulbasaur]
     -  Aerial Ace (+ Fury Cutter)
-   ::damage[Aerial Ace Ranges]{source="Quacklin" special=false offensive=true movePower=60 level=13 healthThreshold=16 opponentLevel=10 stab=true opponentStat=20 theme=error}
+   ::damage[Aerial Ace Ranges]{source="Quacklin" special=false offensive=true movePower=60 level=13 healthThreshold=31 opponentLevel=10 stab=true opponentStat=17 theme=error effectiveness=2 stab=true}
  ::::
  ::::pokemon[Squirtle]
     - If used Fury Cutter 
@@ -910,8 +910,8 @@ Pickup hidden **Power Plant Pass**
     - Low Sweep
  ::::
  ::::pokemon[Golbat]
-    - Rock Tomb
     - Swords Dance
+    - Rock Tomb
       - Give up on Me First, heal if necessary
  ::::
 :::::
@@ -920,7 +920,7 @@ Pickup hidden **Power Plant Pass**
     - Swords Dance
     - Rock Tomb
  ::::
- ::::pokemon[Golbat]
+ ::::pokemon[Mightyena]
     - Low Sweep
  ::::
 :::::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1187,6 +1187,8 @@ Pickup **Rare Candy**
  ::::
 :::::
 
+**If you die to Manectric and Meowstic kills, you will not hit lvl 51 before Lysandre 1. Backup is use Rare Candies at lvl 52 after Swalot. Lysandre 1 Gyarados 13/16 range with 8 Proteins in this case.**
+
 ### Shopping (right):
 > #### Buy
 > - MAX (6-7) Proteins **do not use them yet** (can skip on bad runs)
@@ -1234,9 +1236,9 @@ Pickup **Rare Candy**
     - Shadow Claw
  ::::
  ::::pokemon[Jolteon]{info="Quick Attack can do 7/(8), Discharge 63/(64)" infoColor=blue}
-    - If got Fake Out
+    - If used 2 Swords Dance (Fake Out)
       - Shadow Claw
-    - Otherwise
+    - Otherwise (No Fake Out)
       - Rock Tomb
       - Shadow Claw
  ::::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -207,8 +207,7 @@ Run from Snorlax
 ::::::trainer[Trevor & Tierno]{info="Remember HP after" infoColor=pink}
    - Swords Dance
    :::if{source="Quacklin" condition="atk=(x/20+/x)"} 
-  - Did not get hit on turn 1
-  - Swords Dance
+  - If you didn't take any damage on Turn 1, Swords Dance again
    :::
  :::::pokemon[Corphish]
    - Aerial Ace until dead (Knock Off if Fletchling’s QA could kill Corphish)
@@ -336,9 +335,9 @@ Go to Geosenge centre and catch Hawlucha with Luxury Balls.
   :::
 :::::
 Get massage (conservative estimate 90s for menu → massage, 30s for simple swap)
-  - A little bit more friendly.
-  - Somewhat more friendl
-  - Much more friendly
+  - A little bit more friendly (74%, +5 friendship)
+  - Somewhat more friendly (20%, +10 friendship)
+  - Much more friendly (6%, +30 friendship)
 
 Swap Farfetch’d back to front
 :::::::trainer[Leader Grant]
@@ -391,6 +390,7 @@ Pickup hidden Ether
 Get double massage if possible
 :::::trainer[Swimmer Marissa]
  ::::pokemon[Masquerain]
+    - _Optionally use X-Defense_
     - Swords Dance / Encore on Gust and die
  ::::
 :::::
@@ -503,7 +503,7 @@ Use PP Up if only got one massage and it was bad
      - Wing Attack x2
     :::
     :::if{source="Hawlucha" condition="speed=(x/x/10+) && startingLevel=19"}
-     - Swords Dance
+     - Swords Dance (or X-Speed anyway for friendship gain, Fake Out is most likely outcome)
      - Encore (if no Fake Out/Light Screen, the run is over, heal until Light Screen?)
      - Swords Dance x2
      - Encore
@@ -654,8 +654,9 @@ Pickup **TM47 Low Sweep**
 ####  - Heal Hawlucha to full with Sweet Hearts
 ####  - Repel
 ####  - Teach Rock Smash to Lapras (Slot 1)
-####  - Teach Surf to Lapras (Slot 2)
-####  - Teach Strength to Lapras (Slot 3)
+####  - Teach Strength to Lapras (Slot 2)
+####  - Teach Surf to Lapras (Slot 3)
+####  - Teach Low Sweep to Lucario over Power-Up Punch (Slot 1)
 :::if{source="Hawlucha" condition="speed=(12+/#/#) && startingLevel=19"}
 #### - Teach Rock Tomb to Lucario over Metal Sound (Slot 3)
 :::
@@ -668,7 +669,6 @@ Pickup **TM47 Low Sweep**
 :::if{source="Hawlucha" condition="speed=~(3+/#/#) && startingLevel=20"}
 ####  - Teach Shadow Claw over Metal Sound
 :::
-####  - Teach Low Sweep to Lucario over Power-Up Punch (Slot 1)
 :::::
 :::::::trainer[Pokémon Trainer Calem]
   :::::pokemon[Meowstic]
@@ -792,7 +792,7 @@ Go right after the first climbing rope
 ::::::::::if{source="Hawlucha" condition="speed=~(10-/x/x) && startingLevel=20 || speed=~(18-/x/x) && startingLevel=19"}
 :::::::trainer[Leader Ramos (without Lucario)]
   :::::pokemon[Jumpluff]
-     - Swords Dnace
+     - Swords Dance
      - Wing Attack
      - If Hawlucha dies 
        - Switch to Lucario
@@ -800,49 +800,36 @@ Go right after the first climbing rope
   :::::     
   :::::pokemon[Gogoat]
     :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
-      - Wing Attack at 80+ Attack 
+      - Wing Attack (Low Sweep if Lucario)
     :::
     :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
-      - Flying Press
+      - Flying Press (Low Sweep if Lucario)
     :::
-    - If Lucario
-      - Low Sweep
   :::::
   :::::pokemon[Weepinbell]
-    :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
-      - Wing Attack
-    :::
-    :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
-      - Wing Attack 
-    :::
-    - If Lucario
-      - Low Sweep
+    - Wing Attack (Low Sweep if Lucario)
+
   :::::
 :::::::
 ::::::::::
 ::::::::::if{source="Hawlucha" condition="speed=(10-/x/x) && startingLevel=20 || speed=(18-/x/x) && startingLevel=19"}
 :::::::trainer[Leader Ramos (with Lucario)]
   :::::pokemon[Jumpluff]
-     - Swords Dnace
+     - Swords Dance
      - Rock Tomb
   :::::
   :::::pokemon[Gogoat]
     - Switch to Hawlucha
     - Swords Dance
     :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
-      - Wing Attack  at 80+ Attack 
+      - Wing Attack
     :::
     :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
       - Flying Press
     :::
   :::::
   :::::pokemon[Weepinbell]
-    :::if{source="Hawlucha" condition="atk=(x/x/15+)"}
-      - Wing Attack
-    :::
-    :::if{source="Hawlucha" condition="atk=~(x/x/15+)"}
-      - Wing Attack
-    :::
+    - Wing Attack (Low Sweep if Lucario)
   :::::
 :::::::
 ::::::::::
@@ -862,7 +849,7 @@ Swap Hawlucha with Lucario
 
 Fly to Coumarine
 :::card
-### Shopping (right):
+### Shopping (left):
 > #### Buy
 > - 11 Max Repels (^^) (12 if unconfident in movement)
 > - 1 Escape Rope (^^^)
@@ -902,7 +889,7 @@ Pickup hidden **Power Plant Pass**
 :::::
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Mightyena]{info="12/16 Range" infoColor=red}
-    - Low Sweep
+    - Low Sweep (x2)
  ::::
 :::::
 :::::trainer[Team Flare Grunt]
@@ -912,8 +899,10 @@ Pickup hidden **Power Plant Pass**
  ::::pokemon[Golbat]
     - Swords Dance
     - Rock Tomb
-      - Give up on Me First, heal if necessary
  ::::
+
+Give up on Me First, heal if necessary
+
 :::::
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Golbat]{info="Wing Attack does 27(29)" infoColor=blue}
@@ -926,7 +915,8 @@ Pickup hidden **Power Plant Pass**
 :::::
 :::::trainer[Team Flare Grunt]{info="Body Slam does 10-11/(12)" infoColor=blue}
  ::::pokemon[Swalot]
-    - Bone Rush (5 hits needed)
+    - Bone Rush spam (5 hits needed)
+    - _Finish with Rock Tomb if only one hit left_
  ::::
 :::::
 :::::trainer[Team Flare Grunt]
@@ -934,7 +924,8 @@ Pickup hidden **Power Plant Pass**
     - Low Sweep
  ::::
  ::::pokemon[Swalot]
-    - Bone Rush
+    - Bone Rush spam (4 hits needed)
+    - _Finish with Rock Tomb if only one hit left_
  ::::
 :::::
 :info[Heal if 20 HP or less]{color=yellow}
@@ -950,7 +941,7 @@ Pickup hidden **Power Plant Pass**
  ::::
 :::::
 :::::trainer[Team Flare Admin]
- ::::pokemon[Houndoom]{info="Fire Fang can do 84 (86)" infoColor=blue}
+ ::::pokemon[Houndoom]
     - Low Sweep    
  ::::
 :::::
@@ -962,31 +953,34 @@ Pickup hidden **Power Plant Pass**
 
 :::::trainer[Schoolboy Finnian (Elevator 3)]
 ::::pokemon[Dedenne]
-   - Bone Rush (3 hits) (+ Rock Tomb if only 2)
+   - Bone Rush spam (3 hits needed)
+   - _Finish with Rock Tomb if only one hit left_
 ::::
 :::::
 :::::trainer[Rising Star Estel (Elevator 1)]
  ::::pokemon[Raichu]
-    - Bone Rush (3 hits) (+ Rock Tomb if only 2)
+    - Bone Rush spam (3 hits needed)
+    - _Finish with Rock Tomb if only one hit left_
  ::::
 ::::: 
 :::::trainer[Ace Trainer Rico (Elevator 3)]{info="Thunder Punch does: (33)/34-39/(40)" infoColor=blue}
  ::::pokemon[Ampharos]
-    - Bone Rush (5 hits) (+ Rock Tomb if only 4)
+    - Bone Rush spam (5 hits needed)
+    - _Finish with Rock Tomb if only one hit left_
  ::::
 :::::
 :::::trainer[Poké Fan Lydie (Elevator 2)]
  ::::pokemon[Plusle]
     - Low Sweep
       - Teach Aura Sphere over Low Sweep (Slot 1)
-      - If already taught Aura Sphere, use Bone Rush.
+    - If already taught Aura Sphere, use Bone Rush.
  ::::
 :::::
 :info[Heal if less than 40 HP]{color=yellow}
 :::::trainer[Leader Clemont]
  ::::pokemon[Emolga]
     - Swords Dance
-    - Rock Tomb
+    - _Emolga uses Volt Switch and switches out_
  ::::
  ::::pokemon[Magneton]
     - Bone Rush 
@@ -994,6 +988,8 @@ Pickup hidden **Power Plant Pass**
  ::::pokemon[Heliolisk]
     - Aura Sphere
  ::::
+ ::::pokemon[Emolga]
+    - Rock Tomb
 :::::
 :info[Heal to full]{color=yellow}
 
@@ -1016,21 +1012,21 @@ Pickup **Rare Candy**
 :::::trainer[Leader Valerie]
  ::::pokemon[Mawile]
     - Swords Dance x3
-    - Aura Sphere (Shadow Claw if no Iron Defense)
-      - If Iron Defense turn 1 or 2
-       - Shadow Claw the turn after Iron Defense
+    - If Iron Defense on Turn 1 or 2
+       - Shadow Claw, then finish using Swords Dance
+    - Aura Sphere (Shadow Claw if no Iron Defenses)
  ::::
  ::::pokemon[Mr. Mime]
     - Shadow Claw
  ::::
  ::::pokemon[Sylveon]{info="15/16 Range" infoColor=red}
     - Shadow Claw
-      - If you miss the range and die
-        - Send out Lapras
-        - Perish Song
-        - Revive Lucario
-        - Heal Lucario
-        - Perish Song
+    - If you miss the range and die
+       - Send out Lapras
+       - Perish Song
+       - Revive Lucario
+       - Heal Lucario
+       - Perish Song
  ::::
 :::::
 :info[Heal if 34 (36)]{color=yellow}
@@ -1060,15 +1056,15 @@ Max Repel → Keep applied until off of Mamoswine
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Golbat]
     - Swords Dance
-      - If not hit by Acrobatics
-      - Swords Dance again
-      - Shadow Claw
+    - If not hit by Acrobatics
+       - Swords Dance again
+       - Shadow Claw
     - Otherwise
-      - Rock Tomb
+       - Rock Tomb
  ::::
  ::::pokemon[Manectric]
-    - (2 Swords Dances) Rock Tomb 
-    - (1 Swords Dance)  Shadow Claw (+ Aura Sphere):info[4/16 Range]{color=red}
+    - (If 2 Swords Dances) Rock Tomb 
+    - (If 1 Swords Dance)  Shadow Claw (+ Aura Sphere):info[4/16 Range]{color=red}
     - Give up on Calm Mind
  ::::
 :::::
@@ -1099,7 +1095,7 @@ Pickup **Rare Candy**
     - Shadow Claw
  ::::
  ::::pokemon[Jolteon]{info="Quick Attack can do 7/(8), Discharge 63/(64)" infoColor=blue}
-    - If Faked out
+    - If got Fake Out
       - Shadow Claw
     - Otherwise
       - Rock Tomb
@@ -1150,7 +1146,7 @@ GYM Puzzle
 :::::
 
 :info[Heal if 28 (29) or lower]{color=yellow}
- - _If already level 51_ 
+_If already level 51_ 
    - From the Restore menu
    - Use 2 Rare Candies 
    - 6 Proteins
@@ -1199,7 +1195,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
 :::::
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Swalot]{info="+2 Spit Up does 32/(33) infoColor=blue"}
-    - Swords Dance x2/x3
+    - Swords Dance x2 (x3 if Swalot is still Stockpiled)
     - Shadow Claw
  ::::
 :::::
@@ -1359,7 +1355,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
  ::::
 :::::
 Catch Xerneas with Master Ball
-  - say no to getting him into the party
+  - Select No then Yes to decline adding Xerneas to party
 :::::trainer[Team Flare Lysandre]
  ::::pokemon[Mienfoo]
     - Close Combat

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1560,11 +1560,7 @@ Max Repel
 :::::trainer[Pokémon Professor Sycamore]{info="Remember HP after" infoColor=pink}
  ::::pokemon[Venusaur]
     - Swords Dance
-    - If Damaged
-      - Swords Dance
-      - Close Combat
-    - Otherwise
-      - Close Combat (+ Aura Sphere):info[11/16 Range]{color=red}
+    - Close Combat (+ Aura Sphere) :info[11/16 Range]{color=red}
  ::::
  ::::pokemon[Charizard]
     - Rock Tomb
@@ -1610,7 +1606,7 @@ Free Heal
  ::::
  ::::pokemon[Florges]
     - **If no Static**: Swords Dance + Close Combat
-    - **If Static**: Swords Dance + Full Restore + Close Combat (probably die if get fully paralyzed)
+    - **If Static**: Swords Dance + Full Restore + Close Combat (you die if fully paralyzed on SD turn into Moonblast)
  ::::
  ::::pokemon[Aerodactyl]
     - Rock Tomb
@@ -1618,7 +1614,8 @@ Free Heal
 :::::
 :::::trainer[Pokémon Trainer Trevor (safe)]
  ::::pokemon[Raichu]
-    - Swords Dance (+ heal paralysis)
+    - Swords Dance
+    - Heal para (Raichu always uses Nuzzle)
     - Rock Tomb
  ::::
  ::::pokemon[Florges]

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -363,7 +363,6 @@ Go to Geosenge center and catch Hawlucha with Luxury Balls.
 ####   - Teach Swords Dance over Roost (Slot 2)
 ####   - Teach Rock Smash over Aerial Ace (Slot 3)
 ####   - Swap Oran Berry to Hawlucha if holding it
-  :info[_Optional: Move Swords Dance to slot 2 (for muscle memory_)]{color=yellow}
   :::
   :::if{source="Hawlucha" condition="speed=~(x/24+/1+) && startingLevel=20"}
  ####  - Pick up hidden X-Speed
@@ -513,7 +512,7 @@ Use a Repel
      ::damage[Swords Dance + Karate Chop]{source="Hawlucha" special=false offensive=true healthThreshold=76 movePower=50 combatStages=2 effectiveness=2 level=22 opponentLevel=26 stab=true opponentStat=36 theme=error}
     :::
     :::if{source="Hawlucha" condition="startingLevel=20"}
-     - Rock Smash x2-3
+     - Rock Smash x2 (+ Wing Attack)
      - _If first Rock Smash hits into yellow and gets defense drop, Wing Attack kills_
      - Teach Fling over Rock Smash
     :::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -953,7 +953,7 @@ Go right after the first climbing rope
 > - MAX Hyper Potions (^^) (Should be 19 with standard shopping)
 :::
 
-Use any remaining Sweet Hearts on Hawlucha
+Use any remaining Sweet Hearts on Hawlucha (3 friendship per Sweet Heart)
 
 Get **Lucky Egg**
 
@@ -1002,10 +1002,10 @@ Pickup hidden **Power Plant Pass**
 :::::
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Croagunk]{info="Revenge does 42(44)" infoColor=blue}
-    - Swords Dance
+    - Swords Dance {info="Full Heal if confused" infoColor=blue}
     - Low Sweep
  ::::
- ::::pokemon[Golbat]{info="Full Heal if confused" infoColor=blue}
+ ::::pokemon[Golbat]
     - Rock Tomb
  ::::
 :::::
@@ -1020,7 +1020,7 @@ Pickup hidden **Power Plant Pass**
     - Low Sweep
   ::::
   ::::pokemon[Golbat]
-    - Swords Dance
+    - Swords Dance {info="Full Heal if confused" infoColor=blue}
     - Rock Tomb
     - _Give up on Me First_
   ::::
@@ -1120,7 +1120,8 @@ Use Protein on Lucario
 
 Teach Shadow Claw over Bone Rush (Slot 4)
 
-Max Repel (drop it in the gym, unless feeling very confident about movement)
+Max Repel (drop it in gym)
+
 :::::trainer[Pokémon Trainer Calem]
   ::::pokemon[Meowstic]
     - X-Attack
@@ -1199,7 +1200,7 @@ Max Repel → Keep applied until off of Mamoswine
  ::::pokemon[Manectric]
     - (If 2 Swords Dances) Rock Tomb 
     - (If 1 Swords Dance)  Shadow Claw (+ Aura Sphere):info[4/16 Range]{color=red}
-    - Give up on Calm Mind
+    - _Give up on Calm Mind_
  ::::
 :::::
 :::::trainer[Team Flare Mable]
@@ -1440,7 +1441,7 @@ PC Heal Lucario and Lapras:
  ::::pokemon[Scrafty]
     - Aura Sphere
  ::::
- ::::pokemon[Golbat]{info="5/16 range at L57, 10/16 at L58" infoColor=red}
+ ::::pokemon[Golbat]{info="5/16 range" infoColor=red}
     - Rock Tomb (+ Aura Sphere) 
  ::::
 :::::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1871,7 +1871,7 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
     - Close Combat :info[Shadow Claw 15/16]{color="red"}
  ::::
  ::::pokemon[Altaria]
-    - Shadow Claw
+    - Shadow Claw :info[Rock Tomb if less than 8 Proteins]{color="red"}
  ::::
 :::::
 

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -43,9 +43,13 @@
 :::tracker{species="Lucario" nature="hasty" generation=6 hpIV=6 attackIV=25 defenseIV=16 spAttackIV=25 spDefenseIV=19 speedIV=31 baseStats="[[70, 110, 70, 115, 70, 90]]"}
 :::
 _ported by Fortunate_
+
 _Updated by WaveWarrior_
 
 _notes by wartab_ [base doc](https://docs.google.com/document/d/1eI4u7X_p3weBLY8hAMuaF-LwcAtmqeT3YdLiwZPC0r4/edit)
+
+_8 Protein and 1 Protein Strat_ [base doc](https://pastebin.com/rahQFiqH)
+
 :::card
 Set console date to 14th February and time to 23:03 (adapt for skill level)
 :::
@@ -565,13 +569,11 @@ Get Soothe Bell
 
 Equip **Soothe Bell**
 
-Use Protein
-
 Use Iron
 
 Use HP Up
 
-Use PP Up if both massages were bad
+Use PP Up
 
 :info[Heal to full with Soda Pop]{color=yellow}
 :::::::trainer[Pokémon Trainer Calem]
@@ -620,16 +622,16 @@ Head to the gym
 :::::trainer[Roller Skater Kate]
  ::::pokemon[Meditite]
     - Wing Attack
-    ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=57 theme=error effectiveness=2 evs=16 movePower=60 level=26 opponentLevel=28 stab=true opponentStat=38}
+    ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true healthThreshold=57 theme=error effectiveness=2 movePower=60 level=26 opponentLevel=28 stab=true opponentStat=38}
   
  ::::
  ::::pokemon[Mienfoo]
     - Wing Attack 
     :::if{source="Hawlucha" condition="startingLevel=19"}
-      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error effectiveness=2 stab=true evs=16 movePower=60 level=26 opponentLevel=28 healthThreshold=66 opponentStat=31}
+      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error effectiveness=2 stab=true movePower=60 level=26 opponentLevel=28 healthThreshold=66 opponentStat=31}
     :::
     :::if{source="Hawlucha" condition="startingLevel=20"}
-      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error effectiveness=2 stab=true evs=16 movePower=60 level=27 opponentLevel=28 healthThreshold=66 opponentStat=31}
+      ::damage[Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error effectiveness=2 stab=true movePower=60 level=27 opponentLevel=28 healthThreshold=66 opponentStat=31}
     :::
  ::::
 :::::
@@ -641,10 +643,10 @@ Head to the gym
  ::::pokemon[Throh]
     - Wing Attack
     :::if{source="Hawlucha" condition="startingLevel=19"}
-      ::damage[+2 Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=26 opponentLevel=28 healthThreshold=104 opponentStat=53}
+      ::damage[+2 Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true movePower=60 level=26 opponentLevel=28 healthThreshold=104 opponentStat=53}
     :::
     :::if{source="Hawlucha" condition="startingLevel=20"}
-      ::damage[+2 Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true evs=20 movePower=60 level=27 opponentLevel=28 healthThreshold=104 opponentStat=53}
+      ::damage[+2 Wing Attack Range]{source="Hawlucha" special=false offensive=true theme=error combatStages=2 effectiveness=2 stab=true movePower=60 level=27 opponentLevel=28 healthThreshold=104 opponentStat=53}
     :::
  ::::
  ::::pokemon[Machoke]
@@ -662,9 +664,9 @@ Head to the gym
 Fight Dash first if you already meet the requirements to OHKO Heracross or will not meet them at a higher level
 
 :info[One less IV if fighting Rolanda first at L28]{color=yellow}
-::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
-::damage[L28 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=28 opponentLevel=30 stab=true  opponentStat=52 theme=error}
-::damage[L29 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=20 healthThreshold=91 effectiveness=4 theme=error movePower=60 level=29 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L27 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=27 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L28 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=28 opponentLevel=30 stab=true  opponentStat=52 theme=error}
+::damage[L29 +0 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=91 effectiveness=4 theme=error movePower=60 level=29 opponentLevel=30 stab=true  opponentStat=52 theme=error}
 :::::::trainer[Roller Skater Dash]
   :::::pokemon[Heracross]
     :::if{source="Hawlucha" condition="startingLevel=19"}
@@ -952,9 +954,9 @@ If Hawlucha fainted, PC heal Hawlucha
 > #### Buy
 > - 11 Max Repels (^^) (12 if unconfident in movement)
 > - 1 Escape Rope (^^^)
-> - 11 Full Heals (^)
-> - 3 Revives (v<)
-> - MAX Hyper Potions (^^)
+> - 5 Full Heals (^)
+> - 2 Revive (v<)
+> - 16 Hyper Potions (^^)
 :::
 
 Get **Lucky Egg**
@@ -1108,6 +1110,8 @@ Pickup hidden **Power Plant Pass**
 :::::
 :info[Heal to full]{color=yellow}
 
+Use Protein on Lucario
+
 Teach Shadow Claw over Bone Rush (Slot 4)
 
 Max Repel (drop it in the gym, unless feeling very confident about movement)
@@ -1141,7 +1145,7 @@ Pickup **Rare Candy**
   ::::pokemon[Mr. Mime]
     - Shadow Claw
   ::::
-  ::::pokemon[Sylveon]{info="15/16 Range" infoColor=red}
+  ::::pokemon[Sylveon]
     - Shadow Claw (x2)
     - If you miss the range and die
       - Send out Lapras
@@ -1172,7 +1176,7 @@ Pickup **Rare Candy**
 :::::
 ### Shopping (right):
 > #### Buy
-> - 6 Proteins **do not use them yet**
+> - 7 Proteins **do not use them yet**
 
 :info[Heal if 106 (109) HP or below]{color=yellow}
 
@@ -1197,9 +1201,7 @@ Max Repel → Keep applied until off of Mamoswine
     - Aura Sphere
  ::::
 :::::
-Pickup **PP Up** if had to use the other one
-  - You can pick it up anyway for safety 
-:info[Safety usages are marked in Green]{color=green}
+Pickup **PP Up**
 
 Heal to full
 
@@ -1232,7 +1234,8 @@ Pickup **Rare Candy**
 
 :::::trainer[Psychic Paschal]{info="Remember HP after" infoColor=pink}
  ::::pokemon[Exeggutor]
-    - Shadow Claw x2 (Swords Dance + Shadow Claw 94.5% OHKO, slightly faster)
+    - Swords Dance
+    - Shadow Claw
  ::::
 :::::
 
@@ -1273,7 +1276,7 @@ GYM Puzzle
 
 _If already level 51: Pokemon Menu -> Lucario Restore_
   - _Use 2 Rare Candies_
-  - _6 Proteins_
+  - _7 Proteins_
 
 Fly to the center of Lumiose City
 
@@ -1294,7 +1297,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
 :::::
 - Before entering the bookcase
   - Use 2 Rare Candies
-  - Use all 6 Protein
+  - Use all 7 Protein
   - Heal if 90 or less HP
  
 :::::trainer[Team Flare Lysandre]
@@ -1351,7 +1354,7 @@ Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Pr
  ::::
 :::::
 
-:info[Use PP Up(s) on Close Combat whenever you heal next]{color=red}
+:info[Use PP Up on Close Combat whenever you heal next]{color=red}
 
 :info[Heal to full if 66 (68) HP or less]{color=yellow}
 
@@ -1431,7 +1434,7 @@ PC Heal Lucario and Lapras:
  ::::pokemon[Scrafty]
     - Aura Sphere
  ::::
- ::::pokemon[Golbat]{info="4/16 range at L57, 9/16 at L58" infoColor=red}
+ ::::pokemon[Golbat]{info="5/16 range at L57, 10/16 at L58" infoColor=red}
     - Rock Tomb (+ Aura Sphere) 
  ::::
 :::::
@@ -1479,7 +1482,7 @@ PC Heal Lucario and Lapras:
 
 :info[Heal to full]{color="yellow"}
 
-Use PP Up(s) on Close Combat if haven't yet
+Use PP Up on Close Combat if haven't yet
 
 :::::trainer[Team Flare Double 3]
  ::::pokemon[Scrafty]
@@ -1528,7 +1531,7 @@ Catch Xerneas with Master Ball
  ::::
  ::::pokemon[Honchkrow]
     - Swords Dance 
-    - Rock Tomb :info[Close Combat]{color=green}
+    - Rock Tomb
  ::::
  ::::pokemon[Gyarados]
     - Close Combat
@@ -1545,7 +1548,7 @@ Max Repel
       - Swords Dance
       - Close Combat
     - Otherwise
-      - Close Combat (+ Aura Sphere):info[9/16 Range]{color=red}
+      - Close Combat (+ Aura Sphere):info[11/16 Range]{color=red}
  ::::
  ::::pokemon[Charizard]
     - Rock Tomb
@@ -1584,6 +1587,7 @@ Max Repel
 :::::
 
 Free Heal
+
 :::::trainer[Pokémon Trainer Trevor (slower if Static, faster if no Static)]
  ::::pokemon[Raichu]
     - Close Combat
@@ -1643,7 +1647,7 @@ Fly out of the forest
     - Aura Sphere
  ::::
  ::::pokemon[Jynx]
-    - Rock Tomb  :info[Close Combat]{color=green}
+    - Rock Tomb
  ::::
 :::::
 :::::trainer[Ace Trainer Theo]
@@ -1664,7 +1668,7 @@ Fly out of the forest
     - Aura Sphere
   ::::
   ::::pokemon[Cryogonal]
-    - Close Combat
+    - Close Combat (Rock Tomb if need to save one for Calem)
   ::::
   ::::pokemon[Avalugg]
     - Aura Sphere
@@ -1840,11 +1844,11 @@ Buy Full Restores (>) if none left
  ::::pokemon[Noivern]
     - Close Combat 
  ::::
- ::::pokemon[Druddigon]
+ ::::pokemon[Druddigon] :info[Shadow Claw 15/16]{color="red"}
     - Close Combat
  ::::
  ::::pokemon[Altaria]
-    - Rock Tomb :info[Close Combat]{color=green}
+    - Shadow Claw
  ::::
 :::::
 
@@ -1876,7 +1880,7 @@ Ether Close Combat
  ::::pokemon[Clawitzer]
     - **[Mega Evolve]** Close Combat
  ::::
- ::::pokemon[Gyarados]{info="15/16 range" infoColor=red}
+ ::::pokemon[Gyarados]
     - Swords Dance
     - Close Combat   
  ::::
@@ -1901,7 +1905,7 @@ Ether Close Combat
     - Close Combat
  ::::
  ::::pokemon[Aurorus]
-    - Rock Tomb :info[Close Combat if you took no damage]{color=green}
+    - Rock Tomb
     - If miss, you are at full HP and Aurorus used Reflect
       - Swords Dance
       - If you got hit by Thunder

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -1595,7 +1595,7 @@ Max Repel
 
 Free Heal
 
-:::::trainer[Pokémon Trainer Trevor (slower if Static, faster if no Static)]
+:::::trainer[Pokémon Trainer Trevor (faster on average, slightly risky)]
  ::::pokemon[Raichu]
     - Close Combat
  ::::
@@ -1763,7 +1763,7 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
 :::::
 :::::trainer[Veteran Catrina]
  ::::pokemon[Glaceon]
-    - If Gigalith used Protect on Close Combat and you didn't get safety PP UP
+    - If Gigalith used Protect on Close Combat
       - Swords Dance
       - Rock Tomb
     - Otherwise
@@ -1793,7 +1793,8 @@ Deposit all Pokémon
 
 PC Heal Lucario
 
-Buy Full Restores (>) if none left
+Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
+
 :::::trainer[Elite Four Malva]
  ::::pokemon[Pyroar]
     - Swords Dance 
@@ -1851,8 +1852,8 @@ Buy Full Restores (>) if none left
  ::::pokemon[Noivern]
     - Close Combat 
  ::::
- ::::pokemon[Druddigon] :info[Shadow Claw 15/16]{color="red"}
-    - Close Combat
+ ::::pokemon[Druddigon]
+    - Close Combat :info[Shadow Claw 15/16]{color="red"}
  ::::
  ::::pokemon[Altaria]
     - Shadow Claw

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -414,13 +414,11 @@ Swap Farfetch’d back to front
      ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
     :::
     :::if{source="Hawlucha" condition="atk=(x/16+/25-) && startingLevel=20"}
-      ::damage[Rock Smash Range]{source="Hawlucha" special=false offensive=true healthThreshold=69 combatStages=4 theme=error movePower=40 level=22 effectiveness=2 opponentLevel=25 stab=true  opponentStat=49 theme=error}
-      
-    
+          
       - Rock Smash
       - If Rock Smash crits AND gets defense drop
         - Rock Smash
-      - Else
+      - Otherwise
         - Swords Dance
         - Rock Smash
     :::

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -140,7 +140,7 @@ Get **5 Luxury Balls**
       - Fury Cutter x2
       - _Switch back to Aerial Ace if Withdraw or miss_
     - _Otherwise_
-      - Aerial Ace x2 / x3
+    - Aerial Ace x2 / x3
 
     :::if{source="Quacklin" condition="atk=(x/1-16/x)"}
       :::card{theme=error}

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -397,7 +397,7 @@ Get double massage if possible
 Deposit Farfetch’d
 :::::::trainer[Leader Korrina]
   :::::pokemon[Lucario]
-     - Swords Dance x3
+     - Swords Dance x2-3
      - Karate Chop / Rock Smash (x2)
    :::if{source="Hawlucha" condition="startingLevel=19"}
      ::damage[Rock Smash +4 Range]{source="Hawlucha" special=false offensive=true healthThreshold=75 combatStages=4 theme=error effectiveness=2 movePower=40 level=21 effectiveness=2 opponentLevel=22 stab=true  opponentStat=45 theme=error}
@@ -455,11 +455,11 @@ Use a Repel
 :::::::
 :info[Use a Soda Pop if can die to Confusion (or Super Potion on Shadow Punch if going for +0 range)]{color=yellow}
 :::if{source="Hawlucha" condition="startingLevel=19"}
-::damage[Chimecho’s Confusion does at L24)]{source="Hawlucha" special=true offensive=false movePower=50 level=24 opponentLevel=24 stab=true opponentStat=55}
+::damage[Chimecho’s Confusion does at L24]{source="Hawlucha" special=true offensive=false movePower=50 level=24 opponentLevel=24 stab=true opponentStat=55}
 ::damage[Golett’s Shadow Punch does at L24]{source="Hawlucha" special=false offensive=false movePower=60 level=24 opponentLevel=24 stab=true opponentStat=40}
 :::
 :::if{source="Hawlucha" condition="startingLevel=20"}
-::damage[Chimecho’s Confusion does at L25)]{source="Hawlucha" special=true offensive=false movePower=50 level=25 opponentLevel=24 stab=true opponentStat=55}
+::damage[Chimecho’s Confusion does at L25]{source="Hawlucha" special=true offensive=false movePower=50 level=25 opponentLevel=24 stab=true opponentStat=55}
 ::damage[Golett’s Shadow Punch does at L25]{source="Hawlucha" special=false offensive=false movePower=60 level=25 opponentLevel=24 stab=true opponentStat=40}
 :::
 :::::trainer[Psychic Franz]
@@ -490,7 +490,8 @@ Use Iron
 Use HP Up
 
 Use PP Up if only got one massage and it was bad
-:info[Heal to full with Sweet Hearts]{color=yellow}
+
+:info[Heal to full with Soda Pop]{color=yellow}
 :::::::trainer[Pokémon Trainer Calem]
   :::::pokemon[Meowstic]
     :::if{source="Hawlucha" condition="speed=~(x/x/10+) && startingLevel=19"}
@@ -650,7 +651,7 @@ Pickup **TM47 Low Sweep**
 :::::card
 #### - Say yes to getting Lucario and leave
 ####  - Get Lapras
-####  - Heal Hawlucha to full
+####  - Heal Hawlucha to full with Sweet Hearts
 ####  - Repel
 ####  - Teach Rock Smash to Lapras (Slot 1)
 ####  - Teach Surf to Lapras (Slot 2)
@@ -765,7 +766,7 @@ Go right after the first climbing rope
    ::damage[Exeggutor’s Psyshock does]{source="Hawlucha" special=true offensive=false movePower=80 level=32 opponentLevel=31 stab=true opponentStat=48}
  ::::
 :::::
-:info[Heal to full if can not live Acrobatics from Jumpluff / Take Down from Gogoat]{color=yellow}
+:info[Heal to full (use any remaining Sweet Hearts) if can not live Acrobatics from Jumpluff / Take Down from Gogoat]{color=yellow}
 
 :info[Heal status]{color=yellow}
 :::if{source="Hawlucha" condition="speed=(18-/x/x) && startingLevel=19"}
@@ -781,10 +782,10 @@ Go right after the first climbing rope
    - Teach Rock Tomb over Shadow Claw (slot 3)
 :::
 :::if{source="Hawlucha" condition="startingLevel=19"}
-::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=55 level=32 opponentLevel=30 stab=true opponentStat=44}
+::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=32 opponentLevel=30 stab=true opponentStat=44}
 ::::
 :::if{source="Hawlucha" condition="startingLevel=20"}
-::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=55 level=33 opponentLevel=30 stab=true opponentStat=44}
+::damage[Jumpluff’s Acrobatics does]{source="Hawlucha" special=false offensive=false movePower=110 level=33 opponentLevel=30 stab=true opponentStat=44}
 :::
 ::damage[Take down does]{source="Hawlucha" special=false offensive=false movePower=90 level=33 opponentLevel=34 stab=false opponentStat=88}
 
@@ -1156,6 +1157,8 @@ GYM Puzzle
 
 Fly to the center of Lumiose City
 
+Fight Liepard first if it will give you lvl 51, then use the Rare Candies and Proteins
+
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Scrafty]{info="5/16 range at L50, 14/16 at L53" infoColor=red}
     - Aura Sphere (x2)
@@ -1486,7 +1489,7 @@ Fly out of the forest
     - Aura Sphere
  ::::
  ::::pokemon[Cryogonal]
-    - lose Combat
+    - Close Combat
  ::::
  ::::pokemon[Avalugg]
     - Aura Sphere
@@ -1509,20 +1512,24 @@ Fly out of the forest
     - Aura Sphere
  ::::
 :::::
+
+:info{Heal to full}[color=yellow]
+Teach Shadow Claw over Aura Sphere (Slot 1)
+
 :::::trainer[Pokémon Trainer Calem]
  ::::pokemon[Meowstic]
     - If you have an X-Attack left (and 2 Close Combats)
       - X Attack
     - Otherwise
       - Swords Dance (x2 if Faked Out)
-    - Sadow Claw
+    - Shadow Claw
  ::::
  ::::pokemon[Delphox]
-    - Sadow Claw
+    - Shadow Claw
  ::::
  ::::pokemon[Jolteon]{info="Speed tie without Steadfast boost" infoColor=red}
     - With Swords Dance
-      - Sadow Claw
+      - Shadow Claw
     - With X-Attack
       - Close Combat
  ::::
@@ -1563,7 +1570,7 @@ Fly out of the forest
 :::::
 :::::trainer[Veteran Catrina]
  ::::pokemon[Glaceon]
-    - If Gigalith used Protect on Close Combat
+    - If Gigalith used Protect on Close Combat and you don't have 7 Close Combats
       - Swords Dance
       - Rock Tomb
     - Otherwise

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -102,19 +102,28 @@ Follow the drops in the gym
     -  Aerial Ace
   :::
 ::::
-::::trainer[Leader Viola]
-  :::pokemon[Surskit]
+:::::trainer[Leader Viola]
+  ::::pokemon[Surskit]
     - Aerial Ace
-  :::
-  :::pokemon[Vivillon]
+  ::::
+  ::::pokemon[Vivillon]
     - Aerial Ace spam
-    :::card{theme=error}
-      - 21- Atk (24- IV) 93.8% 2 shot
-      - 22+ Atk (25+ IV) Leer once if Harden (66.8% 2 shot)
+
+    :::if{source="Quacklin" condition="atk=(x/24-/x)"}
+      :::card{theme="error"}
+        - 93.8% 2 shot
+      :::
     :::
+
+    :::if{source="Quacklin" condition="atk=(x/25+/x)"}
+      :::card{theme="error"}
+        - Leer once if Harden (66.8% 2 shot)
+      :::
+    :::
+
     - Teach Knock Off over Fury Attack (Slot 3)
-  :::
-::::
+  ::::
+:::::
 Get the **3 X-Attacks** and **3 X-Defenses** in trainer school.
 
 Grab the **Repel**
@@ -129,6 +138,7 @@ Get **5 Luxury Balls**
   ::::pokemon[Squirtle]
     - If used Fury Cutter 
       - Fury Cutter x2
+      - Switch back to Aerial Ace if Withdraw or miss
     - Otherwise: Aerial Ace x2 / x3
 
     :::if{source="Quacklin" condition="atk=(x/1-16/x)"}

--- a/x-wartab-route/route.mdr
+++ b/x-wartab-route/route.mdr
@@ -281,6 +281,9 @@ Pickup **TM65 Shadow Claw** at the branch after the path goes down
    ::damage[Aerial Ace +2 ranges]{source="Quacklin" special=false combatStages=2 offensive=true movePower=60 level=16 healthThreshold=42 combat opponentLevel=18 stab=true opponentStat=17 theme=error} 
  ::::
 :::::
+
+:info[Heal if necessary]{color="yellow"}
+
 :::::::trainer[Team Flare Grunt]
   :::::pokemon[Gulpin]
     :::if{source="Quacklin" condition="atk=(x/27+/x)"}
@@ -381,7 +384,7 @@ Get massage
 
 Swap Farfetch’d back to front
 :::if{source="Hawlucha" condition="atk=(x/26+/7+) && startingLevel=19"}
-  :info[_Optional: Don't swap Farfetch'd back to front, Karate Chop is 13/16 to kill Amaura with (x/26+/7-26) (guaranteed at x/x/26+)_]{color=red}
+  :info[_Optional: Don't swap Farfetch'd back to front, Karate Chop is 13/16 to kill Amaura with (x/26+/7-26), guaranteed at x/x/26+_]{color=red}
 :::
 
 
@@ -446,13 +449,14 @@ Swap Farfetch’d back to front
     :::
   ::::: 
 :::::::
-Swap Hawlucha to the front of party
 
 Pickup hidden **Protein**
 
 _Optionally pickup X-Defense for friendship gain_
 
 Pickup hidden **Ether**
+
+Swap Hawlucha to the front of party (don't if not getting massage)
 
 Get double massage if possible
 :::::trainer[Swimmer Marissa]
@@ -708,7 +712,7 @@ Head to the gym
   :::::
 :::::::
 
-:info[Heal with Soda Pop unless very high HP (you can heal turn 1 if don't need to X Attack)]
+:info[Heal with Soda Pop unless very high HP (you can heal turn 1 if don't need to X Attack)]{color="yellow"}
 
 :info[You are faster than Korrina's Hawlucha with (x/x/22+)]{color="red"}
 
@@ -848,7 +852,8 @@ Pickup **TM47 Low Sweep**
 Go right after the first climbing rope
 :::::trainer[Pokémon Ranger Chaise]
   ::::pokemon[Simisage]
-   - Flying Press :info[100% at 73+ attack]{color="red"}
+    - Flying Press :info[100% at 73+ attack]{color="red"}
+      ::damage[Flying Press does]{source="Hawlucha" special=false offensive=true movePower=80 level=31 opponentLevel=32 stab=true opponentStat=45 effectiveness=2 theme=error healthThreshold=95}
   ::::
 :::::
 :::::trainer[Pokémon Ranger Brooke]
@@ -873,7 +878,7 @@ Go right after the first climbing rope
  ::::
  ::::pokemon[Exeggutor]
     - Wing Attack
-   ::damage[+2 Wing Attack ranges]{source="Hawlucha" special=false offensive=true evs=32 healthThreshold=104 combatStages=2 effectiveness=2 movePower=60 level=32 opponentLevel=31 stab=true opponentStat=55 theme=error}
+   ::damage[+2 Wing Attack ranges]{source="Hawlucha" special=false offensive=true healthThreshold=104 combatStages=2 effectiveness=2 movePower=60 level=32 opponentLevel=31 stab=true opponentStat=55 theme=error}
    ::damage[Exeggutor’s Psyshock does]{source="Hawlucha" special=true offensive=false movePower=80 level=32 opponentLevel=31 stab=true opponentStat=48}
  ::::
 :::::
@@ -1142,7 +1147,7 @@ Max Repel (drop it in gym)
 Pickup **Rare Candy**
 :::::trainer[Leader Valerie]
   ::::pokemon[Mawile]
-    - Swords Dance x3
+    - Swords Dance x3 (adapt if Mawile uses Iron Defense)
     - If Iron Defense on Turn 1 or 2
       - Shadow Claw
       - Finish setting up Swords Dance
@@ -1158,7 +1163,7 @@ Pickup **Rare Candy**
     - Shadow Claw
   ::::
   ::::pokemon[Sylveon]
-    - Shadow Claw (x2)
+    - Shadow Claw (x2)  :info[15/16 range with 0 Protein, 16/16 with 1 Protein]{color="blue"}
     - If you miss the range and die
       - Send out Lapras
       - Perish Song
@@ -1187,7 +1192,7 @@ Pickup **Rare Candy**
  ::::
 :::::
 
-**If you die to Manectric and Meowstic kills, you will not hit lvl 51 before Lysandre 1. Backup is use Rare Candies at lvl 52 after Swalot. Lysandre 1 Gyarados 13/16 range with 8 Proteins in this case.**
+**If you die to Manectric and Meowstic kills Manectric, you will not hit lvl 51 before Lysandre 1. To fix exp route, use Rare Candies at lvl 52 after Swalot. Lysandre 1 Gyarados 13/16 range with 8 Proteins in this case.**
 
 ### Shopping (right):
 > #### Buy
@@ -1206,14 +1211,14 @@ Max Repel → Keep applied until off of Mamoswine
        - Rock Tomb
  ::::
  ::::pokemon[Manectric]
-    - (If 2 Swords Dances) Rock Tomb 
-    - (If 1 Swords Dance)  Shadow Claw (+ Aura Sphere):info[4/16 Range]{color=red}
+    - **If 2 Swords Dances:** Rock Tomb 
+    - **If 1 Swords Dance:**  Shadow Claw (+ Aura Sphere):info[4/16 Range]{color=red}
     - _Give up on Calm Mind_
  ::::
 :::::
 :::::trainer[Team Flare Mable]
- ::::pokemon[Houndoom]{info="15/16 range" infoColor=red}
-    - Aura Sphere
+ ::::pokemon[Houndoom]{info="Fire Fang does 84-96 (98)" infoColor=red}
+    - Aura Sphere :info[15/16 range]{color="blue"}
  ::::
 :::::
 Pickup **PP Up**
@@ -1248,10 +1253,11 @@ Pickup **Rare Candy**
 :::::
 
 :::::trainer[Psychic Paschal]{info="Remember HP after" infoColor=pink}
- ::::pokemon[Exeggutor]
+  ::::pokemon[Exeggutor]
     - Swords Dance
     - Shadow Claw
- ::::
+    - _If you didn't use a Protein on Lucario, do Shadow Claw x2 instead_
+  ::::
 :::::
 
 :info[Heal if 59 (61) or less HP]{color=yellow}
@@ -1300,8 +1306,10 @@ _If Liepard gives you level 51, fight it first, then use all Rare Candies and Pr
 :::::trainer[Team Flare Grunt]
  ::::pokemon[Scrafty]{info="5/16 range at L50, 14/16 at L53" infoColor=red}
     - Aura Sphere (x2)
-      - Revive Lucario on Hawlucha if died
-      - Wing Attack
+    - _If Lucario dies_
+      - Send in Hawlucha
+      - Revive Lucario
+      - Wing Attack/Aura Sphere
  ::::
 :::::
 :::::trainer[Team Flare Grunt]
@@ -1325,8 +1333,9 @@ _If Liepard gives you level 51, fight it first, then use all Rare Candies and Pr
  ::::pokemon[Gyarados]
     - Switch to Lapras
     - Rock Smash
-      - If no Outrage switch to Hawlucha 
-      - Revive Lapras and try again
+    - _If no Outrage_ 
+      - _Switch to Hawlucha, revive Lapras and try again_
+      - _Yolo strat if full HP: just send in Lucario, Earthquake is 7/16 to kill from full_
     - Switch to Lucario
     - Swords Dance
     - Rock Tomb
@@ -1344,6 +1353,8 @@ _If Liepard gives you level 51, fight it first, then use all Rare Candies and Pr
     - Shadow Claw
  ::::
 :::::
+
+:info[Heal to full if 45 (46) HP or less]{color=yellow}
 
 - Take teleporter
 
@@ -1464,11 +1475,11 @@ PC Heal Lucario and Lapras:
  ::::pokemon[Gyarados]
     - Switch to Lapras
     - Rock Smash
-    - If Lucario not full HP and no Outrage
+    - _If Lucario is not full HP and no Outrage_
       - Swap in Squirtle
       - Heal Lucario to full (Squirtle dies)
       - Switch in Lucario
-    - Otherwise
+    - _Otherwise_
       - Switch in Lucario
     - Swords Dance
     - Rock Tomb
@@ -1705,33 +1716,33 @@ Fly out of the forest
  ::::
 :::::
 
-:info[Heal if 85- HP]{color=yellow}
+:info[Heal if 85 HP or less]{color=yellow}
 
 Teach Shadow Claw over Aura Sphere (Slot 1)
 
 :::::trainer[Pokémon Trainer Calem]
- ::::pokemon[Meowstic]
-    - If you have an X-Attack left (and 2 Close Combats)
+  ::::pokemon[Meowstic]
+    - _If you have an X-Attack and 2 Close Combats left_
       - X Attack
-    - Otherwise
+    - _Otherwise_
       - Swords Dance (again if get Fake Out)
     - Shadow Claw
- ::::
- ::::pokemon[Delphox]
+  ::::
+  ::::pokemon[Delphox]
     - Shadow Claw
- ::::
- ::::pokemon[Jolteon]{info="Speed tie without Steadfast boost" infoColor=red}
+  ::::
+  ::::pokemon[Jolteon]{info="Speed tie without Steadfast boost" infoColor=red}
     - With Swords Dance
       - Shadow Claw
     - With X-Attack
       - Close Combat
- ::::
- ::::pokemon[Altaria]
+  ::::
+  ::::pokemon[Altaria]
     - Rock Tomb
- ::::
- ::::pokemon[Absol]{info="Quick Attack can do 17 at +0 Defense" infoColor=blue}
+  ::::
+  ::::pokemon[Absol]{info="Quick Attack can do 17 at +0 Defense" infoColor=blue}
     - Close Combat
- ::::
+  ::::
 :::::
 
 :info[**Free heal from Ranger**]{color=pink}
@@ -1751,27 +1762,27 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
 :::::trainer[Veteran Timeo]
  ::::pokemon[Trevenant]
     - Shadow Claw
-    - If hit by Will-O-Wisp 
+    - _If hit by Will-O-Wisp_
       - Full Heal
     - Shadow Claw
  ::::
  ::::pokemon[Gigalith]
-    - If Cursed OR if can die to 132-154 (156)
+    - _If Cursed OR if can die to 132-154 (156)_
       - Switch to Hawlucha
       - Wing Attack (then spam Swords Dance/Encore)
       - Switch to Lucario
       - Close Combat
-    - Otherwise
+    - _Otherwise_
       - Shadow Claw
       - Close Combat
  ::::
 :::::
 :::::trainer[Veteran Catrina]
  ::::pokemon[Glaceon]
-    - If Gigalith used Protect on Close Combat
+    - _If Gigalith used Protect on Close Combat_
       - Swords Dance
       - Rock Tomb
-    - Otherwise
+    - _Otherwise_
       - Close Combat
  ::::
  ::::pokemon[Snorlax]
@@ -1782,7 +1793,7 @@ Teach Shadow Claw over Aura Sphere (Slot 1)
 :::::trainer[Veteran Gilles]
  ::::pokemon[Skarmory]{info="Steel Wing can do 27 (28)" infoColor=blue}
     - Shadow Claw
-    - If Steel Wing boost
+    - _If Steel Wing boost_
       - Swords Dance
     - Close Combat
  ::::
@@ -1803,9 +1814,9 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
 :::::trainer[Elite Four Malva]
  ::::pokemon[Pyroar]
     - Swords Dance 
-    - If Noble Roared
+    - _If Noble Roared_
       - Swords Dance
-    - If Burnt
+    - _If Burnt_
       - Full Restore
     - Close Combat
  ::::
@@ -1816,9 +1827,9 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
     - Close Combat
  ::::
  ::::pokemon[Chandelure]
-    - If took more damage than Talonflame QA
+    - _If took more damage than Talonflame QA_
       - Shadow Claw
-    - Otherwise
+    - _Otherwise_
       - Rock Tomb
  ::::
 :::::
@@ -1826,19 +1837,18 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
 :::::trainer[Elite Four Wikstrom]
  ::::pokemon[Klefki] 
     - Swords Dance x2 (Rock Tomb in between if Tormented)
-    - If got hit by 2 Dazzling Gleams
+    - _If got hit by 2 Dazzling Gleams_
       - Hyper Potion
     - Shadow Claw
  ::::
  ::::pokemon[Probopass]{info="Earth Power does 76-88 (90)" infoColor=blue}
     - **No Torment:** Shadow Claw x2
-    - **Otherwise**
+    - **Torment**
       - Rock Tomb (Shadow Claw if you miss) 
       - Close Combat
  ::::
  ::::pokemon[Aegislash]
-    - Shadow Claw
-      - Need to be at 68 HP or lower
+    - Shadow Claw :info[Need to be at 68 HP or lower to not get King's Shield]{color="blue"}
  ::::
  ::::pokemon[Scizor]
     - Heal if 40/(41) +0 Def, 60/(61) -1 Def
@@ -1850,7 +1860,7 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
 :::::trainer[Elite Four Drasna]
  ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
     - Swords Dance x2 
-    - If at 24 HP or less
+    - _If at 24 HP or less_
       - Heal to full
     - Shadow Claw
  ::::
@@ -1868,7 +1878,7 @@ Buy Full Restores (>) if none left or low on Hypers (need 3-4 for rest of game)
 :::::trainer[Elite Four Drasna (safe)]
  ::::pokemon[Dragalge]{info="Thunderbolt does 41-48 (49)" infoColor=blue}
     - Swords Dance x3
-    - If at 24 HP or less
+    - _If at 24 HP or less_
       - Heal to full
     - Shadow Claw
  ::::
@@ -1907,39 +1917,39 @@ Ether Close Combat
 :info[Heal if took any damage]{color=yellow}
 
 :::::trainer[Champion Diantha (fast version, safer version below)]
- ::::pokemon[Hawlucha]
+  ::::pokemon[Hawlucha]
     - Swords Dance 
     - Close Combat
- ::::
- ::::pokemon[Goodra]
+  ::::
+  ::::pokemon[Goodra]
     - Close Combat
- ::::
- ::::pokemon[Tyrantrum]
+  ::::
+  ::::pokemon[Tyrantrum]
     - Close Combat
- ::::
- ::::pokemon[Aurorus]
+  ::::
+  ::::pokemon[Aurorus]
     - Rock Tomb
-    - If miss, you are at full HP and Aurorus used Reflect
+    - _If miss and no Reflect is up_
+      - Rock Tomb again
+    - _If miss, you are at full HP and Aurorus used Reflect_
       - Swords Dance
-      - If you got hit by Thunder
+      - _If you got hit by Thunder_
         - [Meva Evolve] Rock Tomb
-      - If Thunder missed or went for Light Screen
+      - _If Thunder missed or went for Light Screen_
         - Swords Dance 
         - Rock Tomb
-    -If you missed and no Reflect is up
-      - Rock Tomb
- ::::
- ::::pokemon[Gourgeist]
-    - If took damage
+  ::::
+  ::::pokemon[Gourgeist]
+    - _If took damage_
       - Heal to full
-      - If Gourgeist uses Phantom Force and you have X-Defense
+      - _If Gourgeist uses Phantom Force and you have X-Defense_
        >- X-Defense
        >- Heal to full
     - Shadow Claw
- ::::
- ::::pokemon[Gardevoir]
+  ::::
+  ::::pokemon[Gardevoir]
     - Shadow Claw
- ::::
+  ::::
 :::::
 
 :::::trainer[Champion Diantha (safer version)]
@@ -1957,7 +1967,7 @@ Ether Close Combat
     - Close Combat
  ::::
  ::::pokemon[Gourgeist]
-    - If got crit by Hawlucha
+    - _If got crit by Hawlucha_
       - Heal to full
     - Shadow Claw
  ::::
@@ -1968,6 +1978,6 @@ Ether Close Combat
 
 :::::trainer[Trainer AZ]
  ::::pokemon[Torkoal]
-    - Swords Dance x1000
+    - Swords Dance until dead
  ::::
 :::::


### PR DESCRIPTION
**Please include the route in the name of the PR (for example, `AS Any% - Fix Archie 2`)**

## Route ID (for example, `alpha-sapphire-any-percent`)

x-wartab-route

## Summary of changes

- Added 8 Protein and 1 Protein strat (skip Protein on Hawlucha, use it on Lucario, buy 7 in Laverre instead of 6)
- Adjusted damage calcs for 8 Protein strat
- Added notes and damage calcs to many fights
- Added swords dance skip on the first Flare Double fight for some atk values
- Fixed conditionals on Grant and Korrina 1 fights
- Added X-Defense on Masquerain for friendship
- Added backup Ramos fight if Hawlucha dies
- Fixed Clemont fight to account for Volt Switch
- Clarified wording for decision tree on Valerie fight
- Added notes for backup in case you die to Pokeball Factory Double and don't get Manectric exp
- Removed safety Close Combat usages (8 Protein strat is better than 7 Close Combats)
- Added directions for movement in Flare Hideout
- Updated Lysandre 2 fight to be faster in the case where you don't get Outrage
- Updated Sycamore 2 fight to always go for Venasaur range
- Added faster (risky) Bridge Trevor fight
- Updated Close Combat usage in Bridge Trevor to Wulfric section
- Added safe Drasna fight
- Rephrased wordings across the document in a consistent way
- Made sure all the formatting appeared correct on the webpage
- Fixed merge conflicts

## Checklist
* [x] I have tested these changes and Ranger does not display any errors or warnings.
* [x] All image embeds have relative paths.
* [x] The route contains all fights required for the category.
